### PR TITLE
Fix os-specific path issues on unix-like systems

### DIFF
--- a/src/Dependents/point.jl
+++ b/src/Dependents/point.jl
@@ -131,8 +131,8 @@ mutable struct PointRenderer <:RendererDNA{PointDependent}
     _ids::Vector{Float32}
     
     function PointRenderer(context::OpenGLData) 
-        shader_id = ShaderProgram(sp(".\\point\\point_id.vert"), sp(".\\point\\point_id.frag"),["VP"])
-        shader_opaque = ShaderProgram(sp(".\\point\\point.vert"), sp(".\\point\\point.frag"),["VP","selectedID","pickedID","lightDirSideView"])
+        shader_id = ShaderProgram(sp("./point/point_id.vert"), sp("./point/point_id.frag"),["VP"])
+        shader_opaque = ShaderProgram(sp("./point/point.vert"), sp("./point/point.frag"),["VP","selectedID","pickedID","lightDirSideView"])
         renderer = Renderer{PointDependent}(context)
 
         buffer = TypedBufferArray{Tuple{Vec3F,Float32}}()

--- a/src/Dependents/sphere.jl
+++ b/src/Dependents/sphere.jl
@@ -89,9 +89,9 @@ end
 function SphereRenderer(context::OpenGLData)
     renderer = Renderer{SphereDependent}(context)
 
-    shader_id = ShaderProgram(sp(".\\sphere\\sphere_id.vert"),sp(".\\sphere\\sphere_id.geom"),sp(".\\sphere\\sphere_id.frag"),["VP","cam","at","ASPECT_FOV_RESOLUTION"])
-    shader_opaque = ShaderProgram(sp(".\\sphere\\sphere.vert"),sp(".\\sphere\\sphere.geom"),sp(".\\sphere\\sphere_opaque.frag"),["VP","cam","at","lightDirCam","lightDirSide","ASPECT_FOV_RESOLUTION"])
-    shader_transparent = ShaderProgram(sp(".\\sphere\\sphere.vert"),sp(".\\sphere\\sphere.geom"),sp(".\\sphere\\sphere_transparent.frag"),["VP","cam","at","lightDirCam","lightDirSide","ASPECT_FOV_RESOLUTION"])
+    shader_id = ShaderProgram(sp("./sphere/sphere_id.vert"),sp("./sphere/sphere_id.geom"),sp("./sphere/sphere_id.frag"),["VP","cam","at","ASPECT_FOV_RESOLUTION"])
+    shader_opaque = ShaderProgram(sp("./sphere/sphere.vert"),sp("./sphere/sphere.geom"),sp("./sphere/sphere_opaque.frag"),["VP","cam","at","lightDirCam","lightDirSide","ASPECT_FOV_RESOLUTION"])
+    shader_transparent = ShaderProgram(sp("./sphere/sphere.vert"),sp("./sphere/sphere.geom"),sp("./sphere/sphere_transparent.frag"),["VP","cam","at","lightDirCam","lightDirSide","ASPECT_FOV_RESOLUTION"])
 
     buffer_opaque = TypedBufferArray{Tuple{Vec3F,Float32,Vec3F}}()
     buffer_transparent = TypedBufferArray{Tuple{Vec3F,Float32,Vec3F}}()

--- a/src/Dependents/surface.jl
+++ b/src/Dependents/surface.jl
@@ -225,9 +225,9 @@ mutable struct ParametricSurfaceRenderer <: RendererDNA{ParametricSurfaceDepende
     function ParametricSurfaceRenderer(context::OpenGLData)
         renderer = Renderer{ParametricSurfaceDependent}(context)
         
-        shader_id = ShaderProgram(sp(".\\surface\\surface_id.vert"),sp(".\\surface\\surface_id.frag"),["VP"])
-        shader_opaque = ShaderProgram(sp(".\\surface\\surface.vert"),sp(".\\surface\\surface_opaque.frag"),["VP","lightDirCam","lightDirSide"])
-        shader_transparent = ShaderProgram(sp(".\\surface\\surface.vert"),sp(".\\surface\\surface_transparent.frag"),["VP","lightDirCam","lightDirSide"])
+        shader_id = ShaderProgram(sp("./surface/surface_id.vert"),sp("./surface/surface_id.frag"),["VP"])
+        shader_opaque = ShaderProgram(sp("./surface/surface.vert"),sp("./surface/surface_opaque.frag"),["VP","lightDirCam","lightDirSide"])
+        shader_transparent = ShaderProgram(sp("./surface/surface.vert"),sp("./surface/surface_transparent.frag"),["VP","lightDirCam","lightDirSide"])
 
         new(renderer,
         shader_id,shader_opaque,shader_transparent,


### PR DESCRIPTION
On Linux (and presumably also on other Unix-like systems), the "\\" path separator is not working.

As far as I know, in contrast, "/" is working on Windows. If not, we should find out something else.