### PR TITLE
Added forward declarations

### DIFF
--- a/src/Juliagebra.jl
+++ b/src/Juliagebra.jl
@@ -25,6 +25,10 @@ include("commons.jl")
 
 include("abstracts.jl")
 
+# Forward-declare typed globals before any file references them (Julia 1.11 typed globals requirement)
+global implicitApp::Union{AppDNA,Nothing} = nothing
+global greenTask::Union{Any,Nothing} = nothing
+
 # ? ---------------------------------
 # ! Helpers
 # ? ---------------------------------

--- a/src/synchronizer.jl
+++ b/src/synchronizer.jl
@@ -2,8 +2,7 @@
 const DEFAULT_CALLBACK_FUNC() = return nothing
 const DEFAULT_DEPENDENTS = Vector{DependentDNA}()
 
-global implicitApp::Union{AppDNA,Nothing} = nothing
-global greenTask::Union{Any,Nothing} = nothing
+# implicitApp and greenTask are forward-declared in Juliagebra.jl
 
 abstract type FrameState end
 struct BuildingState <: FrameState end


### PR DESCRIPTION
Fixes issue with on Julia 1.11 and win 11. **What happened**: In Julia 1.11, typed globals (`x::T`) became strict — once a binding exists (even implicitly from `global implicitApp` inside a function body in `intersections.jl`), you can't retroactively add a type annotation. Since `intersections.jl` was included at line 114 and `synchronizer.jl` at line 123, the binding already existed untyped by the time the `::Union{AppDNA,Nothing}` declaration ran. Moving the typed declaration earlier (right after `AppDNA` is defined) ensures the type is set before any file references it.