### PR TITLE
GPU-side tessellation for parametric dependents

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,21 +12,27 @@ JuliaGLM = "d62f3426-b328-4065-b1cd-fa40c3c5e4f7"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 ModernGL = "66fc600b-dfda-50eb-8b99-91cfa97b1301"
+ShaderTranspiler = "5f1345c2-4092-4c5f-a4c1-0bd0b6ca6a9b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 ThreadPinning = "811555cd-349b-4f26-b7bc-1f208b848042"
 assimp_jll = "54ae6823-98c6-5a7c-8365-5a43b909f91f"
 glslang_jll = "6fd5517d-459c-5c5a-9b1a-c968b4e37a81"
+stc_jll = "8dead81b-3450-5e2f-948b-0f2a405f2b3d"
 
 [sources]
 JuliaGLM = {rev = "glsl-functions", url = "https://github.com/Csabix/JuliaGLM"}
+ShaderTranspiler = {url = "https://github.com/ShaderTranspiler/ShaderTranspiler.jl"}
+stc_jll = {url = "https://github.com/ShaderTranspiler/stc_jll.jl"}
 
 [compat]
 CEnum = "0.5.0"
 ImPlot = "0.7.5"
 MacroTools = "0.5.16"
+ShaderTranspiler = "0.8.5"
 ThreadPinning = "1.0.2"
 assimp_jll = "5.2.5"
 glslang_jll = "11.7.0"
+stc_jll = "0.8.5"
 
 [extras]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/assets/shaders/src/surface_normals.comp
+++ b/assets/shaders/src/surface_normals.comp
@@ -1,0 +1,36 @@
+#version 460 core
+
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(std430, binding = 0) restrict readonly buffer PositionBuffer {
+    vec4 positions[];
+};
+
+layout(std430, binding = 1) restrict writeonly buffer NormalBuffer {
+    vec4 normals[]; 
+};
+
+uniform ivec2 uvGridSize;
+
+void main() {
+    int u = int(gl_GlobalInvocationID.x);
+    int v = int(gl_GlobalInvocationID.y);
+
+    int height = uvGridSize.x;
+    int width  = uvGridSize.y;
+
+    if (u >= width || v >= height) return;
+
+    int u_left  = max(u - 1, 0);
+    int u_right = min(u + 1, width - 1);
+    int v_up    = max(v - 1, 0);
+    int v_down  = min(v + 1, height - 1);
+
+    vec3 left  = positions[v * width + u_left].xyz;
+    vec3 right = positions[v * width + u_right].xyz;
+    vec3 up    = positions[v_up * width + u].xyz;
+    vec3 down  = positions[v_down * width + u].xyz;
+
+    uint flat_idx = v * width + u;
+    normals[flat_idx] = vec4(normalize(cross(right - left, down - up)), 0);
+}

--- a/examples/m49_torus_knot.jl
+++ b/examples/m49_torus_knot.jl
@@ -1,0 +1,32 @@
+using Juliagebra
+using JuliaGLM
+
+p = 8
+q = 9
+
+TESS_COUNT = 120_000
+
+center1 = Point(3.5, 0, 0)
+center2 = Point(-3.5, 0, 0)
+
+@callback_helper function torus_knot(phi::Float32)
+    r = cos(9 * phi) + 2
+
+    x = r * cos(8 * phi)
+    y = r * sin(8 * phi)
+    z = -sin(9 * phi)
+    
+    return Vec3F(x, y, z)
+end
+
+# CPU
+ParametricCurve(range(0, 2pi, TESS_COUNT), [center1]) do phi, o
+    return o["xyz"] + torus_knot(Float32(phi))
+end
+
+# GPU
+@ParametricCurve(range(0, 2pi, TESS_COUNT), enable_gpu_tessellation=true) do phi
+    return center2["xyz"] + torus_knot(Float32(phi))
+end
+
+Juliagebra.Wait()

--- a/examples/m49_torus_knot.jl
+++ b/examples/m49_torus_knot.jl
@@ -1,32 +1,51 @@
 using Juliagebra
 using JuliaGLM
 
-p = 8
-q = 9
+const TESS_COUNT = 225_000
 
-TESS_COUNT = 120_000
+p_cpu = Slider(-20,8,20;label="p CPU")
+q_cpu = Slider(-20,9,20;label="q CPU")
 
-center1 = Point(3.5, 0, 0)
+p_gpu = Slider(-20,8,20;label="p GPU")
+q_gpu = Slider(-20,9,20;label="q GPU")
+
+flip_cpu = Toggle(;label="Flip CPU")
+flip_gpu = Toggle(;label="Flip GPU")
+
+dist_amp_cpu = Slider(0,0,2pi;label="Distortion Amplitude CPU")
+dist_phase_cpu = Stepper(0.0;label="Distortion Phase CPU")
+
+dist_amp_gpu = Slider(0,0,2pi;label="Distortion Amplitude GPU")
+dist_phase_gpu = Stepper(0.0;label="Distortion Phase GPU")
+
+center1 = Point( 3.5, 0, 0)
 center2 = Point(-3.5, 0, 0)
 
-@callback_helper function torus_knot(phi::Float32)
-    r = cos(9 * phi) + 2
+@callback_helper function torus_knot(p::Float32, q::Float32, phi::Float32,
+                                     dist_amp::Float32, dist_phase::Float32, flip::Bool)
+    r = cos(q * phi) + 2
 
-    x = r * cos(8 * phi)
-    y = r * sin(8 * phi)
-    z = -sin(9 * phi)
+    x = r * cos(p * phi)
+    y = r * sin(p * phi)
+    z = sin(q * phi) * (2 * Int32(flip) - 1)
     
-    return Vec3F(x, y, z)
+    return Vec3F(x, y, z) .+ (sin(phi + dist_phase) * dist_amp)
 end
 
 # CPU
-ParametricCurve(range(0, 2pi, TESS_COUNT), [center1]) do phi, o
-    return o["xyz"] + torus_knot(Float32(phi))
+@ParametricCurve(range(0, 2pi, TESS_COUNT)) do phi
+    return center1 + torus_knot(
+        Float32(p_cpu), Float32(q_cpu), Float32(phi),
+        Float32(dist_amp_cpu), Float32(dist_phase_cpu), flip_cpu
+    )
 end
 
 # GPU
 @ParametricCurve(range(0, 2pi, TESS_COUNT), enable_gpu_tessellation=true) do phi
-    return center2["xyz"] + torus_knot(Float32(phi))
+    return center2 + torus_knot(
+        Float32(p_gpu), Float32(q_gpu), Float32(phi),
+        Float32(dist_amp_gpu), Float32(dist_phase_gpu), flip_gpu
+    )
 end
 
 Juliagebra.Wait()

--- a/examples/m50_bryant_kusner.jl
+++ b/examples/m50_bryant_kusner.jl
@@ -1,0 +1,55 @@
+using Juliagebra
+using JuliaGLM
+
+CPU_TESS = 1000
+GPU_TESS = 1000
+
+P1 = Point(-2, 0, 0)
+P2 = Point( 2, 0, 0)
+
+@callback_helper function comp_mul(x::Vec2, y::Vec2)
+    _re = x.x * y.x - x.y * y.y
+    _im = x.y * y.x + x.x * y.y
+
+    return vec2(_re, _im)
+end
+
+@callback_helper function comp_div(x::Vec2, y::Vec2)
+    denom = y.x * y.x + y.y * y.y
+
+    _re = (x.x * y.x + x.y * y.y) / denom
+    _im = (x.y * y.x - x.x * y.y) / denom
+
+    return vec2(_re, _im)
+end
+
+@callback_helper function bryant_kusner(r::Float32, theta::Float32)
+    w = vec2(r * cos(theta), r * sin(theta))
+    w3 = comp_mul(comp_mul(w, w), w)
+    w4 = comp_mul(w3, w)
+    w6 = comp_mul(comp_mul(w4, w), w)
+
+    g_denom = w6 + comp_mul(vec2(sqrt(5), 0), w3) - vec2(1, 0)
+
+    g1_base = comp_div(comp_mul(w, vec2(1, 0) - w4), g_denom)
+    g1 = -1.5 * g1_base.y
+
+    g2_base = comp_div(comp_mul(w, vec2(1, 0) + w4), g_denom)
+    g2 = -1.5 * g2_base.x
+
+    g3_base = comp_div(vec2(1, 0) + w6, g_denom)
+    g3 = g3_base.y - 0.5
+
+    pos_denom = g1 * g1 + g2 * g2 + g3 * g3
+    return vec3(g1, g2, g3) / pos_denom
+end
+
+@ParametricSurface(range(0,1,GPU_TESS),range(0,2pi,GPU_TESS),enable_gpu_tessellation=true) do r, theta
+    return P1 + vec3(0, 0, 3) + bryant_kusner(r, theta)
+end
+
+@ParametricSurface(range(0,1,CPU_TESS),range(0,2pi,CPU_TESS)) do r, theta
+    return P2 + vec3(0, 0, 3) + bryant_kusner(Float32(r), Float32(theta))
+end
+
+Juliagebra.Wait()

--- a/examples/m50_bryant_kusner.jl
+++ b/examples/m50_bryant_kusner.jl
@@ -1,11 +1,25 @@
 using Juliagebra
 using JuliaGLM
 
-CPU_TESS = 1000
-GPU_TESS = 1000
+TESS_RADIUS = 1000
+TESS_THETA = 1000
 
 P1 = Point(-2, 0, 0)
 P2 = Point( 2, 0, 0)
+
+angle_cpu = Stepper(0.0;label="Rotation Angle CPU")
+angle_gpu = Stepper(0.0;label="Rotation Angle GPU")
+
+@callback_helper function rotate_z(v::Vec3, angle::Float32)
+    c = cos(angle)
+    s = sin(angle)
+    
+    return Vec3F(
+        c * v.x - s * v.y,
+        s * v.x + c * v.y,
+        v.z
+    )
+end
 
 @callback_helper function comp_mul(x::Vec2, y::Vec2)
     _re = x.x * y.x - x.y * y.y
@@ -41,15 +55,15 @@ end
     g3 = g3_base.y - 0.5
 
     pos_denom = g1 * g1 + g2 * g2 + g3 * g3
-    return vec3(g1, g2, g3) / pos_denom
+    return vec3(g1, g2, g3) / Float32(pos_denom)
 end
 
-@ParametricSurface(range(0,1,GPU_TESS),range(0,2pi,GPU_TESS),enable_gpu_tessellation=true) do r, theta
-    return P1 + vec3(0, 0, 3) + bryant_kusner(r, theta)
+@ParametricSurface(range(0,1,TESS_RADIUS),range(0,2pi,TESS_THETA)) do r, theta
+    return P2 + vec3(0, 0, 3) + rotate_z(bryant_kusner(Float32(r), Float32(theta)), Float32(angle_cpu))
 end
 
-@ParametricSurface(range(0,1,CPU_TESS),range(0,2pi,CPU_TESS)) do r, theta
-    return P2 + vec3(0, 0, 3) + bryant_kusner(Float32(r), Float32(theta))
+@ParametricSurface(range(0,1,TESS_RADIUS),range(0,2pi,TESS_THETA),enable_gpu_tessellation=true) do r, theta
+    return P1 + vec3(0, 0, 3) + rotate_z(bryant_kusner(r, theta), Float32(angle_gpu))
 end
 
 Juliagebra.Wait()

--- a/src/Dependents/Gui/slider.jl
+++ b/src/Dependents/Gui/slider.jl
@@ -28,6 +28,12 @@ evalCallbackDpEntry(self::SliderDependent)::Float64 = return Float64(self._value
 
 evalCallbackDpReturn(self::SliderDependent, v::Vec3F) = self._value = v
 
+get_glsl_representation(::Type{SliderDependent}) = Float32
+function try_upload_dependent(uniform::GLint, s::SliderDependent)::Bool
+    glUniform1f(uniform, s._value.y)
+    return true
+end
+
 # ? ---------------------------------
 # ! SliderRenderer
 # ? ---------------------------------

--- a/src/Dependents/Gui/stepper.jl
+++ b/src/Dependents/Gui/stepper.jl
@@ -25,6 +25,12 @@ evalCallbackDpEntry(self::StepperDependent)::Float64 = return self._num
 
 evalCallbackDpReturn(self::StepperDependent,num::Float64) = self._num = num
 
+get_glsl_representation(::Type{StepperDependent}) = Float32
+function try_upload_dependent(uniform::GLint, s::StepperDependent)::Bool
+    glUniform1f(uniform, s._num)
+    return true
+end
+
 # ? ---------------------------------
 # ! StepperRenderer
 # ? ---------------------------------

--- a/src/Dependents/Gui/toggle.jl
+++ b/src/Dependents/Gui/toggle.jl
@@ -33,6 +33,12 @@ evalCallbackDpEntry(self::ToggleDependent)::Bool = return self._state
 evalCallbackDpReturn(self::ToggleDependent, val::Bool) = self._state = val
 evalCallbackDpReturn(self::ToggleDependent, ::Nothing) = return nothing
 
+get_glsl_representation(::Type{ToggleDependent}) = Bool
+function try_upload_dependent(uniform::GLint, t::ToggleDependent)::Bool
+    glUniform1i(uniform, GLint(t._state))
+    return true
+end
+
 # ? ---------------------------------
 # ! ToggleRenderer
 # ? ---------------------------------

--- a/src/Dependents/curve.jl
+++ b/src/Dependents/curve.jl
@@ -33,7 +33,7 @@ mutable struct ParametricCurveDependent <: ParametricDependentDNA
     end
 end
 
-Base.string(self::ParametricCurveDependent)::String =  return "ParametricCurve: $(length(self._range))"
+Base.string(self::ParametricCurveDependent)::String = return "ParametricCurve: $(length(self._range))"
 _ParametricDependent_(self::ParametricCurveDependent)::ParametricDependent = return self._parametricDependent
 _RenderedDependent_(self::ParametricCurveDependent)::RenderedDependent = return _ParametricDependent_(self)._renderedDependent
 
@@ -42,7 +42,7 @@ Base.eltype(dependent::ParametricCurveDependent)::DataType = Vector{Vec3D}
 # YELLOW Thread
 # RED Thread
 function onNodeEval(self::ParametricCurveDependent)
-    eval_callbacks!(self)    
+    eval_callbacks!(self)
 end
 
 function eval_callbacks_cpu!(self::ParametricCurveDependent)
@@ -84,27 +84,30 @@ function handle_gpu_tess_result!(self::ParametricCurveDependent)::Bool
     # TODO: measure impact of pre-allocating staging buffers per gpu-tessellated dependent vs on the fly
     dep::ParametricDependent = _ParametricDependent_(self)
 
-    copyto!(dep._stagingBuffer, 1, dep._outBuffer._mapped, 1, dep._sampleCount)
+    @time_cpu_begin ParametricTessellation GPU DataProcessing Download
+    copyto!(dep._stagingBuffer, 1, dep._posBuffer._mapped, 1, dep._sampleCount)
+    @time_cpu_end ParametricTessellation GPU DataProcessing Download
 
+    @time_cpu_begin ParametricTessellation GPU DataProcessing evalCallbackDpReturn
     for i in eachindex(dep._stagingBuffer)
         v4 = dep._stagingBuffer[i]
-        
         v3 = Vec3D(v4.x, v4.y, v4.z)
-        
+
         any(x -> isnan(x) || isinf(x), v3) && return false
-        
+
         evalCallbackDpReturn(self, v3, i)
     end
+    @time_cpu_end ParametricTessellation GPU DataProcessing evalCallbackDpReturn
 
     return true
 end
 
 function try_transpile_tess_shader(self::ParametricCurveDependent)::Union{ShaderProgram,Nothing}
     @time_cpu_begin GPUTessSetup CodeGen CurveWrapperCodeGen
-    
+
     dep::ParametricDependent = _ParametricDependent_(self)
     fn_data = splitdef(dep._callbackAST)
-    
+
     if isempty(get(fn_data, :args, []))
         @log "cannot transpile zero argument function as a parametric curve callback" WARN
         return nothing
@@ -117,7 +120,7 @@ function try_transpile_tess_shader(self::ParametricCurveDependent)::Union{Shader
     pushfirst!(fn_data[:body].args, :(
         $t_varname = $GPU_TESS_T_RANGE[:x] + Float32($GPU_TESS_ID) * $GPU_TESS_T_RANGE[:y]
     ))
-    
+
     dep._callbackAST = combinedef(fn_data)
     @time_cpu_end GPUTessSetup CodeGen CurveWrapperCodeGen
 

--- a/src/Dependents/curve.jl
+++ b/src/Dependents/curve.jl
@@ -39,9 +39,6 @@ _RenderedDependent_(self::ParametricCurveDependent)::RenderedDependent = return 
 
 Base.eltype(dependent::ParametricCurveDependent)::DataType = Vector{Vec3D}
 
-# force GPU tessellated dependents to OpenGL's thread
-thread_affinity(self::ParametricCurveDependent, ::Model) = is_gpu_tessellated(self) ? 0 : -1
-
 # YELLOW Thread
 # RED Thread
 function onNodeEval(self::ParametricCurveDependent)
@@ -74,11 +71,13 @@ evalCallbackDpReturn(self::ParametricCurveDependent,v::Nothing,index)           
 function pre_gpu_tess!(self::ParametricCurveDependent)
     shader = _ParametricDependent_(self)._tessCompShader
     @assert shader !== nothing "GPU tessellation pipeline invoked on CPU-tessellated parametric dependent"
+    @assert self._range isa StepRange || self._range isa StepRangeLen "GPU tessellation currently only supports StepRanges"
+
 
     # currently assumes uniformly spaced tessellation params (which AbstractRange-s are)
     # this minimizes required CPU -> GPU upload, but can be changed later to stream non-uniform distributions
     glUniform1ui(shader.uniforms[GPU_TESS_N_STR], GLuint(length(self._range)))
-    glUniform2f(shader.uniforms[GPU_TESS_T_RANGE_STR], first(self._range), last(self._range))
+    glUniform2f(shader.uniforms[GPU_TESS_T_RANGE_STR], first(self._range), step(self._range))
 end
 
 function handle_gpu_tess_result!(self::ParametricCurveDependent)::Bool
@@ -116,8 +115,7 @@ function try_transpile_tess_shader(self::ParametricCurveDependent)::Union{Shader
 
     # add code for calculating the t parameter GPU-side, assuming uniform spacing
     pushfirst!(fn_data[:body].args, :(
-        $t_varname = 
-            (Float32($GPU_TESS_ID) / Float32($GPU_TESS_N - 1)) * ($GPU_TESS_T_RANGE[:y] - $GPU_TESS_T_RANGE[:x]) + $GPU_TESS_T_RANGE[:x]
+        $t_varname = $GPU_TESS_T_RANGE[:x] + Float32($GPU_TESS_ID) * $GPU_TESS_T_RANGE[:y]
     ))
     
     dep._callbackAST = combinedef(fn_data)

--- a/src/Dependents/curve.jl
+++ b/src/Dependents/curve.jl
@@ -81,7 +81,6 @@ function pre_gpu_tess!(self::ParametricCurveDependent)
 end
 
 function handle_gpu_tess_result!(self::ParametricCurveDependent)::Bool
-    # TODO: measure impact of pre-allocating staging buffers per gpu-tessellated dependent vs on the fly
     dep::ParametricDependent = _ParametricDependent_(self)
 
     @time_cpu_begin ParametricTessellation GPU DataProcessing Download

--- a/src/Dependents/curve.jl
+++ b/src/Dependents/curve.jl
@@ -1,10 +1,13 @@
+# identifiers used in generated tessellation shaders
+const GPU_TESS_T_RANGE = :JG_TESS_T_RANGE
+const GPU_TESS_T_RANGE_STR = string(GPU_TESS_T_RANGE)
 
 # ? ---------------------------------
 # ! ParametricCurveDependent
 # ? ---------------------------------
 
-mutable struct ParametricCurveDependent <: RenderedDependentDNA
-    _renderedDependent::RenderedDependent
+mutable struct ParametricCurveDependent <: ParametricDependentDNA
+    _parametricDependent::ParametricDependent
     
     _range::AbstractRange{Float64}
     _colors::Vector{UInt32}
@@ -17,21 +20,35 @@ mutable struct ParametricCurveDependent <: RenderedDependentDNA
     function ParametricCurveDependent(
         callback::Function,dependents::Vector{<:DependentDNA},
         range::AbstractRange{Float64},
-        color::Vector{UInt32},style::UInt8,size::Float32)
-        dependent = RenderedDependent(callback,dependents)
-        tValues = Vector{Vec3D}(undef,length(range))
+        color::Vector{UInt32},style::UInt8,size::Float32,
+        callback_ast::Union{Expr,Nothing},dependent_bindings::Union{Dict{Symbol, <:DependentDNA},Nothing})
+        N = length(range)
+        dependent = if callback_ast === nothing || dependent_bindings === nothing
+            ParametricDependent(callback,dependents)
+        else
+            ParametricDependent(callback,dependents,callback_ast,dependent_bindings,N)
+        end
+        tValues = Vector{Vec3D}(undef,N)
         new(dependent,range,color,size,style,tValues)
     end
 end
 
 Base.string(self::ParametricCurveDependent)::String =  return "ParametricCurve: $(length(self._range))"
-_RenderedDependent_(self::ParametricCurveDependent)::RenderedDependent = return self._renderedDependent
+_ParametricDependent_(self::ParametricCurveDependent)::ParametricDependent = return self._parametricDependent
+_RenderedDependent_(self::ParametricCurveDependent)::RenderedDependent = return _ParametricDependent_(self)._renderedDependent
 
 Base.eltype(dependent::ParametricCurveDependent)::DataType = Vector{Vec3D}
+
+# force GPU tessellated dependents to OpenGL's thread
+thread_affinity(self::ParametricCurveDependent, ::Model) = is_gpu_tessellated(self) ? 0 : -1
 
 # YELLOW Thread
 # RED Thread
 function onNodeEval(self::ParametricCurveDependent)
+    eval_callbacks!(self)    
+end
+
+function eval_callbacks_cpu!(self::ParametricCurveDependent)
     for index in 1:length(self._range)
         evalCallbackDp(self; callbackParams = self._range[index], returnParams = (index))
     end
@@ -51,6 +68,63 @@ evalCallbackDpReturn(self::ParametricCurveDependent,v::Vec3F,index)             
 evalCallbackDpReturn(self::ParametricCurveDependent,v::Vec2D,index)              = self._tValues[index] = Vec3D(v[1],v[2],0.0)
 evalCallbackDpReturn(self::ParametricCurveDependent,v::Vec2F,index)              = self._tValues[index] = Vec3D(v[1],v[2],0.0)
 evalCallbackDpReturn(self::ParametricCurveDependent,v::Nothing,index)            = self._tValues[index] = Vec3DNan
+
+# ? methods for GPU tessellation
+
+function pre_gpu_tess!(self::ParametricCurveDependent)
+    shader = _ParametricDependent_(self)._tessCompShader
+    @assert shader !== nothing "GPU tessellation pipeline invoked on CPU-tessellated parametric dependent"
+
+    # currently assumes uniformly spaced tessellation params (which AbstractRange-s are)
+    # this minimizes required CPU -> GPU upload, but can be changed later to stream non-uniform distributions
+    glUniform1ui(shader.uniforms[GPU_TESS_N_STR], GLuint(length(self._range)))
+    glUniform2f(shader.uniforms[GPU_TESS_T_RANGE_STR], first(self._range), last(self._range))
+end
+
+function handle_gpu_tess_result!(self::ParametricCurveDependent)::Bool
+    # TODO: measure impact of pre-allocating staging buffers per gpu-tessellated dependent
+    dep::ParametricDependent = _ParametricDependent_(self)
+
+    staging_buffer = data(dep._outBuffer)
+
+    for i in 1:length(staging_buffer)
+        v4 = staging_buffer[i]
+        
+        v3 = Vec3D(v4.x, v4.y, v4.z)
+        
+        any(x -> isnan(x) || isinf(x), v3) && return false
+        
+        evalCallbackDpReturn(self, v3, i)
+    end
+
+    return true
+end
+
+function try_transpile_tess_shader(self::ParametricCurveDependent)::Union{ShaderProgram,Nothing}
+    @time_cpu_begin GPUTessSetup CodeGen CurveWrapperCodeGen
+    
+    dep::ParametricDependent = _ParametricDependent_(self)
+    fn_data = splitdef(dep._callbackAST)
+    
+    if isempty(get(fn_data, :args, []))
+        @log "cannot transpile zero argument function as a parametric curve callback" WARN
+        return nothing
+    end
+
+    t_varname = namify(fn_data[:args][1]) # first argument is the parameter (t)
+    popat!(fn_data[:args], 1)
+
+    # add code for calculating the t parameter GPU-side, assuming uniform spacing
+    pushfirst!(fn_data[:body].args, :(
+        $t_varname = 
+            (Float32($GPU_TESS_ID) / Float32($GPU_TESS_N - 1)) * ($GPU_TESS_T_RANGE[:y] - $GPU_TESS_T_RANGE[:x]) + $GPU_TESS_T_RANGE[:x]
+    ))
+    
+    dep._callbackAST = combinedef(fn_data)
+    @time_cpu_end GPUTessSetup CodeGen CurveWrapperCodeGen
+
+    return try_transpile_tess_shader_base(dep._callbackAST, dep._dependentBindings, [(GPU_TESS_T_RANGE_STR, Vec2)])
+end
 
 # ? For Intersectable ParametricCurves.
 
@@ -127,16 +201,22 @@ Dependent2Observer(app::AppDNA,::ParametricCurveDependent) = getDependentObserve
 # YELLOW Thread
 function ParametricCurve(callback::Function,range::AbstractRange{Float64},
                 dependents::Vector{<:DependentDNA}=DependentDNA[],color_style::Union{Nothing,String}=nothing;
-                color="c",style="-",size=5.0f0)::ParametricCurveDependent
+                color="c",style="-",size=5.0f0,
+                enable_gpu_tessellation::Bool=false,callback_ast::Union{Expr,Nothing}=nothing,
+                dependent_bindings::Union{Dict{Symbol, <:DependentDNA},Nothing}=nothing)::ParametricCurveDependent
+    if !enable_gpu_tessellation
+        callback_ast = nothing
+        dependent_bindings = nothing
+    end 
     (c,s) = parse_line_colors_style(color_style,color,style)
-    return Build!(ParametricCurveDependent(callback,dependents,range,c,s,Float32(size)))
+    return Build!(ParametricCurveDependent(callback,dependents,range,c,s,Float32(size),callback_ast,dependent_bindings))
 end
 
 macro ParametricCurve(callback::Expr,range,args...)
-    (positional_args, kw_args) = _parse_macro_arguments((:color_style,),(:color, :style, :size), args...)
+    (positional_args, kw_args) = _parse_macro_arguments((:color_style,),(:color, :style, :size, :enable_gpu_tessellation), args...)
     callback = _validate_callback_expr(callback, 1)
     return _create_ctor_wrapper(callback, __module__, Juliagebra.ParametricCurve,
-                                positional_args, kw_args, (cb, deps) -> (cb, range, deps))
+                                positional_args, kw_args, (cb, deps) -> (cb, range, deps), true)
 end
 
 export ParametricCurve

--- a/src/Dependents/curve.jl
+++ b/src/Dependents/curve.jl
@@ -81,13 +81,13 @@ function pre_gpu_tess!(self::ParametricCurveDependent)
 end
 
 function handle_gpu_tess_result!(self::ParametricCurveDependent)::Bool
-    # TODO: measure impact of pre-allocating staging buffers per gpu-tessellated dependent
+    # TODO: measure impact of pre-allocating staging buffers per gpu-tessellated dependent vs on the fly
     dep::ParametricDependent = _ParametricDependent_(self)
 
-    staging_buffer = data(dep._outBuffer)
+    copyto!(dep._stagingBuffer, 1, dep._outBuffer._mapped, 1, dep._sampleCount)
 
-    for i in 1:length(staging_buffer)
-        v4 = staging_buffer[i]
+    for i in eachindex(dep._stagingBuffer)
+        v4 = dep._stagingBuffer[i]
         
         v3 = Vec3D(v4.x, v4.y, v4.z)
         

--- a/src/Dependents/dependents.jl
+++ b/src/Dependents/dependents.jl
@@ -10,6 +10,7 @@ const _TRIANGLE_CLUSTERS::UInt = 8
 include("parsers.jl")
 include("dependent_renderer.jl")
 include("rendered_dependent.jl")
+include("parametric_dependent.jl")
 include("Gui/gui_renderer.jl")
 include("Gui/gui_dependent.jl")
 include("point.jl")

--- a/src/Dependents/extra_model_abstracts.jl
+++ b/src/Dependents/extra_model_abstracts.jl
@@ -3,6 +3,9 @@
 abstract type RenderedDependentDNA  <: SubjectDNA end
 abstract type RendererDNA{T<:RenderedDependentDNA} <: ObserverDNA{RenderedDependentDNA} end
 
+# ? For dependents who may be tessellated on the GPU
+abstract type ParametricDependentDNA <: RenderedDependentDNA end
+
 # ? For Subject-Observers who use ImGui.
 abstract type GuiDependentDNA <: SubjectDNA end
 abstract type GuiRendererDNA{T<:GuiDependentDNA} <: ObserverDNA{GuiDependentDNA} end

--- a/src/Dependents/parametric_dependent.jl
+++ b/src/Dependents/parametric_dependent.jl
@@ -2,8 +2,6 @@ const GPU_TESS_LOCAL_SIZE = 256
 const GPU_TESS_POS_BINDING_IDX = 0
 const GPU_TESS_DEBUG_ARG = "--debug-gpu-tess"
 
-# TODO: gui and other simple dependent uploads
-
 get_glsl_representation(::Type{T}) where {T<:DependentDNA} = Nothing
 try_upload_dependent(uniform::GLint, dep::DependentDNA)::Bool = return false
 
@@ -124,8 +122,6 @@ handle_gpu_tess_result!(self::ParametricDependentDNA)::Bool = error("Missing fun
 
 function eval_callbacks!(self::ParametricDependentDNA)
     @assert is_valid_parametric_dependent(self) "eval_callbacks! called with uninitialized or otherwise invalid parametric dependent"
-
-    # TODO: timings
 
     if is_cpu_tessellated(self)
         @time_cpu_begin ParametricTessellation CPU

--- a/src/Dependents/parametric_dependent.jl
+++ b/src/Dependents/parametric_dependent.jl
@@ -1,0 +1,175 @@
+const GPU_TESS_LOCAL_SIZE = 256
+const GPU_TESS_POS_BINDING_IDX = 0
+const GPU_TESS_DEBUG_ARG = "--debug-gpu-tess"
+
+# TODO: gui and other simple dependent uploads
+
+get_glsl_representation(::Type{T}) where {T<:DependentDNA} = Nothing
+try_upload_dependent(uniform::GLint, dep::DependentDNA)::Bool = return false
+
+# ? ---------------------------------
+# ! ParametricDependentDNA
+# ? ---------------------------------
+
+mutable struct ParametricDependent <: RenderedDependentDNA
+    _renderedDependent::RenderedDependent
+    
+    _callbackAST::Union{Expr, Nothing}
+    _dependentBindings::Union{Dict{Symbol, <:DependentDNA}, Nothing}
+    _tessCompShader::Union{ShaderProgram, Nothing}
+    _outBuffer::Union{MappedBuffer{Vec4}, Nothing}
+    _sampleCount::Int # num of vec4-s in _outBuffer
+
+    function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA})
+        renderedDependent = RenderedDependent(callback,dependents)
+        return new(renderedDependent, nothing, nothing, nothing, nothing, 0)
+    end
+
+    function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA},
+                                 callbackAST::Expr, dependentBindings::Dict{Symbol, <:DependentDNA},
+                                 sampleCount::Int)
+        renderedDependent = RenderedDependent(callback,dependents)
+
+        return new(renderedDependent, callbackAST, dependentBindings, nothing, nothing, sampleCount)
+    end
+end
+
+_ParametricDependent_(self::ParametricDependentDNA)::ParametricDependent = error("Missing \"_ParametricDependent_\" func for instance of ParametricDependentDNA")
+_RenderedDependent_(self::ParametricDependentDNA)::RenderedDependent = _ParametricDependent_(self)._renderedDependent
+_Subject_(self::ParametricDependentDNA)::Subject = _RenderedDependent_(self)._subject
+
+# ensures GPU resources are initialized prior to first tessellation
+function node_start!(self::ParametricDependentDNA)
+    start_time = time_ns()
+    setup_parametric_dependent!(self)
+
+    beforeNodeEval(self)
+    onNodeEval(self)
+    afterNodeEval(self)
+end
+
+function is_valid_parametric_dependent(self::ParametricDependentDNA)::Bool
+    dep::ParametricDependent = _ParametricDependent_(self)
+    gpu_props = (dep._callbackAST, dep._dependentBindings, dep._tessCompShader, dep._outBuffer)
+    return all(isnothing, gpu_props) || !any(isnothing, gpu_props)
+end
+
+is_gpu_tessellated(self::DependentDNA)::Bool = false
+is_gpu_tessellated(self::ParametricDependentDNA)::Bool = _ParametricDependent_(self)._tessCompShader !== nothing
+
+is_cpu_tessellated(self::DependentDNA)::Bool = !is_gpu_tessellated(self)
+
+function force_cpu_tessellation!(self::ParametricDependentDNA)
+    dep::ParametricDependent = _ParametricDependent_(self)
+
+    dep._callbackAST = nothing
+    dep._dependentBindings = nothing
+    dep._sampleCount = 0
+    
+    dep._tessCompShader !== nothing && destroy!(dep._tessCompShader)
+    dep._tessCompShader = nothing
+    
+    dep._outBuffer !== nothing && destroy!(dep._outBuffer)
+    dep._outBuffer = nothing
+end
+
+# must be invoked on opengl thread
+try_transpile_tess_shader(::ParametricDependentDNA)::Union{ShaderProgram, Nothing} = error("Missing try_transpile_tess_shader func for instance of ParametricDependentDNA")
+
+# must be invoked on opengl thread
+function setup_parametric_dependent!(self::ParametricDependentDNA)
+    dep::ParametricDependent = _ParametricDependent_(self)
+    @assert dep._tessCompShader === nothing && dep._outBuffer === nothing "setup_parametric_dependent! called on dependent that has already been initialized"
+
+    # CPU tessellated dependent
+    dep._callbackAST === nothing && return
+
+    @time_cpu_begin GPUTessSetup
+
+    @time_cpu_begin GPUTessSetup CodeGen
+    tess_shader = try_transpile_tess_shader(self)
+    @time_cpu_end GPUTessSetup CodeGen
+    
+    if tess_shader !== nothing
+        dep._tessCompShader = tess_shader
+
+        dep._outBuffer = MappedBuffer{Vec4}(; read = true, write = false)
+        reserve!(dep._outBuffer, dep._sampleCount, 0)
+    else
+        dep._callbackAST = nothing
+        dep._dependentBindings = nothing
+    end
+
+    @assert is_valid_parametric_dependent(self) "parametric dependent in invalid state after setup"
+
+    @time_cpu_end GPUTessSetup
+end
+
+# called before the tessellation shader is dispatched, can be used for uniform uploads and such
+pre_gpu_tess!(::ParametricDependentDNA) = nothing
+
+# Should update `self` according to the data read back from the GPU after tessellation
+# This should be (mostly) equivalent to how the CPU tessellation updates the dependent
+# _outBuffer has been updated and sync-d by the time this function is invoked
+# False return value indicates failures and forces fallback to CPU tessellation
+handle_gpu_tess_result!(self::ParametricDependentDNA)::Bool = error("Missing func handle_gpu_tess_result! func for instance of ParametricDependentDNA")
+
+function eval_callbacks!(self::ParametricDependentDNA)
+    @assert is_valid_parametric_dependent(self) "eval_callbacks! called with uninitialized or otherwise invalid parametric dependent"
+
+    # TODO: timings
+
+    if is_cpu_tessellated(self)
+        eval_callbacks_cpu!(self)
+        return
+    end
+
+    eval_callbacks_gpu!(self) && return
+
+    # unsuccessful gpu tessellation
+
+    @log "Error during GPU tessellation of dependent #$(_Dependent_(self)._graphID), falling back to CPU" WARN
+
+    force_cpu_tessellation!(self)
+
+    eval_callbacks_cpu!(self)
+end
+
+# should handle the entire CPU-side tessellation pipeline, including the updating of `self`
+eval_callbacks_cpu!(self::ParametricDependentDNA) = error("Missing eval_callbacks_cpu! func for instance of ParametricDependentDNA")
+
+function eval_callbacks_gpu!(self::ParametricDependentDNA)
+    dep::ParametricDependent = _ParametricDependent_(self)
+
+    activate(dep._tessCompShader)
+
+    pre_gpu_tess!(self)
+
+    for (parent_sym, parent_dep) in dep._dependentBindings
+        success = try_upload_dependent(dep._tessCompShader.uniforms[string(parent_sym)], parent_dep)
+        !success && return false
+    end
+
+    bind_ssbo(dep._outBuffer, GPU_TESS_POS_BINDING_IDX)
+
+    num_wg = div(dep._sampleCount + GPU_TESS_LOCAL_SIZE - 1, GPU_TESS_LOCAL_SIZE)
+
+    glDispatchCompute(num_wg, 1, 1)
+
+    glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT)
+
+    fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+    while true
+        waitReturn = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 1000000)
+        if waitReturn == GL_ALREADY_SIGNALED || waitReturn == GL_CONDITION_SATISFIED
+            break
+        elseif waitReturn == GL_WAIT_FAILED
+            glDeleteSync(fence)
+            return false
+        end
+    end
+    glDeleteSync(fence)
+
+    return handle_gpu_tess_result!(self)
+end
+

--- a/src/Dependents/parametric_dependent.jl
+++ b/src/Dependents/parametric_dependent.jl
@@ -38,6 +38,9 @@ _ParametricDependent_(self::ParametricDependentDNA)::ParametricDependent = error
 _RenderedDependent_(self::ParametricDependentDNA)::RenderedDependent = _ParametricDependent_(self)._renderedDependent
 _Subject_(self::ParametricDependentDNA)::Subject = _RenderedDependent_(self)._subject
 
+# force GPU tessellated dependents to OpenGL's thread
+thread_affinity(self::ParametricDependentDNA, ::Model) = is_gpu_tessellated(self) ? 0 : -1
+
 # ensures GPU resources are initialized prior to first tessellation
 function node_start!(self::ParametricDependentDNA)
     start_time = time_ns()

--- a/src/Dependents/parametric_dependent.jl
+++ b/src/Dependents/parametric_dependent.jl
@@ -13,25 +13,26 @@ try_upload_dependent(uniform::GLint, dep::DependentDNA)::Bool = return false
 
 mutable struct ParametricDependent <: RenderedDependentDNA
     _renderedDependent::RenderedDependent
-    
-    _callbackAST::Union{Expr, Nothing}
-    _dependentBindings::Union{Dict{Symbol, <:DependentDNA}, Nothing}
-    _tessCompShader::Union{ShaderProgram, Nothing}
-    _outBuffer::Union{MappedBuffer{Vec4}, Nothing}
-    _sampleCount::Int # num of vec4-s in _outBuffer
+
+    _callbackAST::Union{Expr,Nothing}
+    _dependentBindings::Union{Dict{Symbol,<:DependentDNA},Nothing}
+    _tessCompShader::Union{ShaderProgram,Nothing}
+    _posBuffer::Union{MappedBuffer{Vec4},Nothing}
+    _sampleCount::Int # num of vec4-s in pos buffer
     _stagingBuffer::Vector{Vec4}
 
     function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA})
-        renderedDependent = RenderedDependent(callback,dependents)
+        renderedDependent = RenderedDependent(callback, dependents)
         return new(renderedDependent, nothing, nothing, nothing, nothing, 0, Vec4[])
     end
 
     function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA},
-                                 callbackAST::Expr, dependentBindings::Dict{Symbol, <:DependentDNA},
-                                 sampleCount::Int)
-        renderedDependent = RenderedDependent(callback,dependents)
+        callbackAST::Expr, dependentBindings::Dict{Symbol,<:DependentDNA},
+        sampleCount::Int)
+        renderedDependent = RenderedDependent(callback, dependents)
 
-        return new(renderedDependent, callbackAST, dependentBindings, nothing, nothing, sampleCount, Vector{Vec4}(undef, sampleCount))
+        return new(renderedDependent, callbackAST, dependentBindings, nothing,
+                   nothing, sampleCount, Vector{Vec4}(undef, sampleCount))
     end
 end
 
@@ -44,7 +45,6 @@ thread_affinity(self::ParametricDependentDNA, ::Model) = is_gpu_tessellated(self
 
 # ensures GPU resources are initialized prior to first tessellation
 function node_start!(self::ParametricDependentDNA)
-    start_time = time_ns()
     setup_parametric_dependent!(self)
 
     beforeNodeEval(self)
@@ -69,21 +69,21 @@ function force_cpu_tessellation!(self::ParametricDependentDNA)
     dep._callbackAST = nothing
     dep._dependentBindings = nothing
     dep._sampleCount = 0
-    
+
     dep._tessCompShader !== nothing && destroy!(dep._tessCompShader)
     dep._tessCompShader = nothing
-    
-    dep._outBuffer !== nothing && destroy!(dep._outBuffer)
-    dep._outBuffer = nothing
+
+    dep._posBuffer !== nothing && destroy!(dep._posBuffer)
+    dep._posBuffer = nothing
 end
 
 # must be invoked on opengl thread
-try_transpile_tess_shader(::ParametricDependentDNA)::Union{ShaderProgram, Nothing} = error("Missing try_transpile_tess_shader func for instance of ParametricDependentDNA")
+try_transpile_tess_shader(::ParametricDependentDNA)::Union{ShaderProgram,Nothing} = error("Missing try_transpile_tess_shader func for instance of ParametricDependentDNA")
 
 # must be invoked on opengl thread
 function setup_parametric_dependent!(self::ParametricDependentDNA)
     dep::ParametricDependent = _ParametricDependent_(self)
-    @assert dep._tessCompShader === nothing && dep._outBuffer === nothing "setup_parametric_dependent! called on dependent that has already been initialized"
+    @assert dep._tessCompShader === nothing && dep._posBuffer === nothing "setup_parametric_dependent! called on dependent that has already been initialized"
 
     # GPU tessellated dependent
     if dep._callbackAST !== nothing
@@ -92,12 +92,11 @@ function setup_parametric_dependent!(self::ParametricDependentDNA)
         @time_cpu_begin GPUTessSetup CodeGen
         tess_shader = try_transpile_tess_shader(self)
         @time_cpu_end GPUTessSetup CodeGen
-        
+
         if tess_shader !== nothing
             dep._tessCompShader = tess_shader
-
-            dep._outBuffer = MappedBuffer{Vec4}(; read = true, write = false)
-            reserve!(dep._outBuffer, dep._sampleCount, 0)
+            dep._posBuffer = MappedBuffer{Vec4}(; read = true, write = false)
+            reserve!(dep._posBuffer, dep._sampleCount, 0)
         else
             dep._callbackAST = nothing
             dep._dependentBindings = nothing
@@ -119,7 +118,7 @@ pre_gpu_tess!(::ParametricDependentDNA) = nothing
 
 # Should update `self` according to the data read back from the GPU after tessellation
 # This should be (mostly) equivalent to how the CPU tessellation updates the dependent
-# _outBuffer has been updated and sync-d by the time this function is invoked
+# _posBuffer has been updated and sync-d by the time this function is invoked
 # False return value indicates failures and forces fallback to CPU tessellation
 handle_gpu_tess_result!(self::ParametricDependentDNA)::Bool = error("Missing func handle_gpu_tess_result! func for instance of ParametricDependentDNA")
 
@@ -129,11 +128,17 @@ function eval_callbacks!(self::ParametricDependentDNA)
     # TODO: timings
 
     if is_cpu_tessellated(self)
+        @time_cpu_begin ParametricTessellation CPU
         eval_callbacks_cpu!(self)
+        @time_cpu_end ParametricTessellation CPU
         return
     end
 
-    eval_callbacks_gpu!(self) && return
+    @time_cpu_begin ParametricTessellation GPU
+    success = eval_callbacks_gpu!(self)
+    @time_cpu_end ParametricTessellation GPU
+
+    success && return
 
     # unsuccessful gpu tessellation
 
@@ -141,7 +146,9 @@ function eval_callbacks!(self::ParametricDependentDNA)
 
     force_cpu_tessellation!(self)
 
+    @time_cpu_begin ParametricTessellation CPU
     eval_callbacks_cpu!(self)
+    @time_cpu_end ParametricTessellation CPU
 end
 
 # should handle the entire CPU-side tessellation pipeline, including the updating of `self`
@@ -152,33 +159,44 @@ function eval_callbacks_gpu!(self::ParametricDependentDNA)
 
     activate(dep._tessCompShader)
 
+    @time_gpu_begin ParametricTessellation GPU UploadAndCompute
     pre_gpu_tess!(self)
 
     for (parent_sym, parent_dep) in dep._dependentBindings
         success = try_upload_dependent(dep._tessCompShader.uniforms[string(parent_sym)], parent_dep)
-        !success && return false
+        if !success
+            @time_gpu_end ParametricTessellation GPU UploadAndCompute
+            return false
+        end
     end
 
-    bind_ssbo(dep._outBuffer, GPU_TESS_POS_BINDING_IDX)
+    bind_ssbo(dep._posBuffer, GPU_TESS_POS_BINDING_IDX)
 
     num_wg = div(dep._sampleCount + GPU_TESS_LOCAL_SIZE - 1, GPU_TESS_LOCAL_SIZE)
 
     glDispatchCompute(num_wg, 1, 1)
+    @time_gpu_end ParametricTessellation GPU UploadAndCompute
 
     glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT)
 
+    @time_cpu_begin ParametricTessellation GPU ClientFence
     fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
     while true
         waitReturn = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 1000000)
         if waitReturn == GL_ALREADY_SIGNALED || waitReturn == GL_CONDITION_SATISFIED
             break
         elseif waitReturn == GL_WAIT_FAILED
+            @time_cpu_end ParametricTessellation GPU ClientFence
             glDeleteSync(fence)
             return false
         end
     end
     glDeleteSync(fence)
+    @time_cpu_end ParametricTessellation GPU ClientFence
 
-    return handle_gpu_tess_result!(self)
+    @time_cpu_begin ParametricTessellation GPU DataProcessing
+    success = handle_gpu_tess_result!(self)
+    @time_cpu_end ParametricTessellation GPU DataProcessing
+
+    return success
 end
-

--- a/src/Dependents/parametric_dependent.jl
+++ b/src/Dependents/parametric_dependent.jl
@@ -19,10 +19,11 @@ mutable struct ParametricDependent <: RenderedDependentDNA
     _tessCompShader::Union{ShaderProgram, Nothing}
     _outBuffer::Union{MappedBuffer{Vec4}, Nothing}
     _sampleCount::Int # num of vec4-s in _outBuffer
+    _stagingBuffer::Vector{Vec4}
 
     function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA})
         renderedDependent = RenderedDependent(callback,dependents)
-        return new(renderedDependent, nothing, nothing, nothing, nothing, 0)
+        return new(renderedDependent, nothing, nothing, nothing, nothing, 0, Vec4[])
     end
 
     function ParametricDependent(callback::Function, dependents::Vector{<:DependentDNA},
@@ -30,7 +31,7 @@ mutable struct ParametricDependent <: RenderedDependentDNA
                                  sampleCount::Int)
         renderedDependent = RenderedDependent(callback,dependents)
 
-        return new(renderedDependent, callbackAST, dependentBindings, nothing, nothing, sampleCount)
+        return new(renderedDependent, callbackAST, dependentBindings, nothing, nothing, sampleCount, Vector{Vec4}(undef, sampleCount))
     end
 end
 
@@ -53,7 +54,7 @@ end
 
 function is_valid_parametric_dependent(self::ParametricDependentDNA)::Bool
     dep::ParametricDependent = _ParametricDependent_(self)
-    gpu_props = (dep._callbackAST, dep._dependentBindings, dep._tessCompShader, dep._outBuffer)
+    gpu_props = (dep._callbackAST, dep._dependentBindings, dep._tessCompShader)
     return all(isnothing, gpu_props) || !any(isnothing, gpu_props)
 end
 
@@ -84,29 +85,34 @@ function setup_parametric_dependent!(self::ParametricDependentDNA)
     dep::ParametricDependent = _ParametricDependent_(self)
     @assert dep._tessCompShader === nothing && dep._outBuffer === nothing "setup_parametric_dependent! called on dependent that has already been initialized"
 
-    # CPU tessellated dependent
-    dep._callbackAST === nothing && return
+    # GPU tessellated dependent
+    if dep._callbackAST !== nothing
+        @time_cpu_begin GPUTessSetup
 
-    @time_cpu_begin GPUTessSetup
+        @time_cpu_begin GPUTessSetup CodeGen
+        tess_shader = try_transpile_tess_shader(self)
+        @time_cpu_end GPUTessSetup CodeGen
+        
+        if tess_shader !== nothing
+            dep._tessCompShader = tess_shader
 
-    @time_cpu_begin GPUTessSetup CodeGen
-    tess_shader = try_transpile_tess_shader(self)
-    @time_cpu_end GPUTessSetup CodeGen
-    
-    if tess_shader !== nothing
-        dep._tessCompShader = tess_shader
+            dep._outBuffer = MappedBuffer{Vec4}(; read = true, write = false)
+            reserve!(dep._outBuffer, dep._sampleCount, 0)
+        else
+            dep._callbackAST = nothing
+            dep._dependentBindings = nothing
+        end
 
-        dep._outBuffer = MappedBuffer{Vec4}(; read = true, write = false)
-        reserve!(dep._outBuffer, dep._sampleCount, 0)
-    else
-        dep._callbackAST = nothing
-        dep._dependentBindings = nothing
+        @time_cpu_end GPUTessSetup
     end
 
-    @assert is_valid_parametric_dependent(self) "parametric dependent in invalid state after setup"
+    post_setup_parametric_dependent!(self)
 
-    @time_cpu_end GPUTessSetup
+    @assert is_valid_parametric_dependent(self) "parametric dependent in invalid state after setup"
 end
+
+# hook for any additional OpenGL setup
+post_setup_parametric_dependent!(self::ParametricDependentDNA) = nothing
 
 # called before the tessellation shader is dispatched, can be used for uniform uploads and such
 pre_gpu_tess!(::ParametricDependentDNA) = nothing

--- a/src/Dependents/point.jl
+++ b/src/Dependents/point.jl
@@ -37,6 +37,12 @@ evalCallbackDpReturn(self::PointDependent,value::Vec3F) = self._coord = Vec3D(va
 evalCallbackDpReturn(self::PointDependent,value::Vec3D) = self._coord = value
 evalCallbackDpReturn(self::PointDependent,::Nothing) = self._coord = Vec3DNan
 
+get_glsl_representation(::Type{PointDependent}) = Vec3F
+function try_upload_dependent(uniform::GLint, pt::PointDependent)::Bool
+    glUniform3f(uniform, Vec3F(pt._coord)...)
+    return true
+end
+
 # ? ---------------------------------
 # ! Points
 # ? ---------------------------------

--- a/src/Dependents/point.jl
+++ b/src/Dependents/point.jl
@@ -39,7 +39,7 @@ evalCallbackDpReturn(self::PointDependent,::Nothing) = self._coord = Vec3DNan
 
 get_glsl_representation(::Type{PointDependent}) = Vec3F
 function try_upload_dependent(uniform::GLint, pt::PointDependent)::Bool
-    glUniform3f(uniform, Vec3F(pt._coord)...)
+    glUniform3f(uniform, Float32.(pt._coord)...)
     return true
 end
 

--- a/src/Dependents/surface.jl
+++ b/src/Dependents/surface.jl
@@ -69,8 +69,8 @@ function post_setup_parametric_dependent!(self::ParametricSurfaceDependent)
     
     # force creation of position buffer so that normal calculations can always rely on it
     if dep._callbackAST === nothing
-        dep._outBuffer = MappedBuffer{Vec4}(; read = false, write = true)
-        reserve!(dep._outBuffer, n, 0)
+        dep._posBuffer = MappedBuffer{Vec4}(; read = false, write = true)
+        reserve!(dep._posBuffer, n, 0)
     end
 end
 
@@ -109,8 +109,13 @@ end
 function onNodeEval(self::ParametricSurfaceDependent)
     eval_callbacks!(self)
 
-    # update_normals_cpu!(self)
-    update_normals_gpu!(self)
+    @time_cpu_begin ParametricTessellation UpdateNormals
+    if "--cpu-normals" in ARGS
+        update_normals_cpu!(self)
+    else
+        update_normals_gpu!(self)
+    end
+    @time_cpu_end ParametricTessellation UpdateNormals
 end
 
 function eval_callbacks_cpu!(self::ParametricSurfaceDependent)
@@ -183,14 +188,16 @@ function update_normals_gpu!(self::ParametricSurfaceDependent)
 
     dep::ParametricDependent = _ParametricDependent_(self)
 
+    @time_gpu_begin ParametricTessellation UpdateNormals MaybeUploadAndCompute
+
     if is_cpu_tessellated(self)
-        @assert dep._outBuffer !== nothing "parametric surface without out buffer (position buffer)"
-        
+        @assert dep._posBuffer !== nothing "parametric surface without out buffer (position buffer)"
+
         # first normal calc after GPU -> CPU fallback state
-        if !dep._outBuffer._write
-            dep._outBuffer._write = true
-            dep._outBuffer._read  = false
-            reserve!(dep._outBuffer, n, 0)
+        if !dep._posBuffer._write
+            dep._posBuffer._write = true
+            dep._posBuffer._read = false
+            reserve!(dep._posBuffer, n, 0)
         end
 
         i = 1
@@ -201,37 +208,47 @@ function update_normals_gpu!(self::ParametricSurfaceDependent)
             end
         end
 
-        copyto!(dep._outBuffer, dep._stagingBuffer)
+        copyto!(dep._posBuffer, dep._stagingBuffer)
     end
 
     normals_shader = getOpenGL(implicitApp)._surface_normals
     activate(normals_shader) # TODO: use SPIRV
     glUniform2i(normals_shader.uniforms["uvGridSize"], GLint(height(self._uvValues)), GLint(width(self._uvValues)))
 
-    bind_ssbo(dep._outBuffer, 0)
+    bind_ssbo(dep._posBuffer, 0)
     bind_ssbo(self._normalsBuffer, 1)
 
     glDispatchCompute(div(w + 15, 16), div(h + 15, 16), 1)
+    @time_gpu_end ParametricTessellation UpdateNormals MaybeUploadAndCompute
 
     glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT)
+
+    @time_gpu_begin ParametricTessellation UpdateNormals ClientFence
     fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
     while true
         waitReturn = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 1000000);
         if waitReturn == GL_ALREADY_SIGNALED || waitReturn == GL_CONDITION_SATISFIED
             break
         elseif waitReturn == GL_WAIT_FAILED
-            @log "Failed to sync after dispatching surface normal calculation compute shader" ERR
+            @log "Failed to sync client after dispatching surface normal calculation compute shader" ERR
+            @time_gpu_end ParametricTessellation UpdateNormals ClientFence
             glDeleteSync(fence)
+            return
         end
     end
     glDeleteSync(fence)
+    @time_gpu_end ParametricTessellation UpdateNormals ClientFence
 
+    @time_cpu_begin ParametricTessellation UpdateNormals DataProcessing Download
     copyto!(dep._stagingBuffer, 1, self._normalsBuffer._mapped, 1, n)
+    @time_cpu_end ParametricTessellation UpdateNormals DataProcessing Download
 
+    @time_cpu_begin ParametricTessellation UpdateNormals DataProcessing Update
     for v in 1:h, u in 1:w
         v4 = dep._stagingBuffer[(v - 1) * w + u]
         self._uvNormals[u, v] = Vec3D(v4.x, v4.y, v4.z)
     end
+    @time_cpu_end ParametricTessellation UpdateNormals DataProcessing Update
 end
 
 # ? methods for GPU tessellation
@@ -250,22 +267,29 @@ end
 
 function handle_gpu_tess_result!(self::ParametricSurfaceDependent)::Bool
     dep::ParametricDependent = _ParametricDependent_(self)
-    
-    copyto!(dep._stagingBuffer, 1, dep._outBuffer._mapped, 1, dep._sampleCount)
-    
+
+    @time_cpu_begin ParametricTessellation GPU DataProcessing Download
+    copyto!(dep._stagingBuffer, 1, dep._posBuffer._mapped, 1, dep._sampleCount)
+    @time_cpu_end ParametricTessellation GPU DataProcessing Download
+
+    @time_cpu_begin ParametricTessellation GPU DataProcessing evalCallbackDpReturn
     i::Int = 1
     for v in 1:height(self._uvValues)
         for u in 1:width(self._uvValues)
             v4 = dep._stagingBuffer[i]
             v3 = Vec3F(v4.x, v4.y, v4.z)
 
-            any(x -> isnan(x) || isinf(x), v3) && return false
-            
+            if any(x -> isnan(x) || isinf(x), v3)
+                @time_cpu_end ParametricTessellation GPU DataProcessing evalCallbackDpReturn
+                return false
+            end
+
             evalCallbackDpReturn(self, v3, u, v)
 
             i += 1
         end
     end
+    @time_cpu_end ParametricTessellation GPU DataProcessing evalCallbackDpReturn
 
     # sync before gpu-side normal calculation
     glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT)
@@ -275,7 +299,7 @@ end
 
 function try_transpile_tess_shader(self::ParametricSurfaceDependent)::Union{ShaderProgram,Nothing}
     @time_cpu_begin GPUTessSetup CodeGen SurfaceWrapperCodeGen
-    
+
     dep::ParametricDependent = _ParametricDependent_(self)
 
     fn_data = splitdef(dep._callbackAST)
@@ -395,7 +419,7 @@ function ParametricSurface(callback::Function,
     if !enable_gpu_tessellation
         callback_ast = nothing
         dependent_bindings = nothing
-    end 
+    end
     c = isnothing(color_data) ? get_color(color) : get_color(color_data)
     Build!(ParametricSurfaceDependent(callback,dependents,uRange,vRange,c,callback_ast,dependent_bindings))
 end

--- a/src/Dependents/surface.jl
+++ b/src/Dependents/surface.jl
@@ -212,7 +212,7 @@ function update_normals_gpu!(self::ParametricSurfaceDependent)
     end
 
     normals_shader = getOpenGL(implicitApp)._surface_normals
-    activate(normals_shader) # TODO: use SPIRV
+    activate(normals_shader) # TODO: use SPIRV pipeline
     glUniform2i(normals_shader.uniforms["uvGridSize"], GLint(height(self._uvValues)), GLint(width(self._uvValues)))
 
     bind_ssbo(dep._posBuffer, 0)
@@ -256,7 +256,6 @@ end
 function pre_gpu_tess!(self::ParametricSurfaceDependent)
     shader = _ParametricDependent_(self)._tessCompShader
     @assert shader !== nothing "GPU tessellation pipeline invoked on CPU-tessellated parametric dependent"
-    # TODO: proper range upload
     @assert (self._uRange isa StepRange || self._uRange isa StepRangeLen) &&
             (self._vRange isa StepRange || self._vRange isa StepRangeLen) "GPU tessellation currently only supports StepRanges"
 

--- a/src/Dependents/surface.jl
+++ b/src/Dependents/surface.jl
@@ -20,13 +20,16 @@ mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: ParametricDep
 
     _color::UInt32
 
+    _normalsBuffer::Union{MappedBuffer{Vec4},Nothing}
+
     # YELLOW Thread
     function ParametricSurfaceDependent(
         callback::Function,dependents::Vector{<:DependentDNA},
         uRange::Range,
         vRange::Range,
         color::UInt32,
-        callback_ast::Union{Expr,Nothing},dependent_bindings::Union{Dict{Symbol, <:DependentDNA},Nothing}
+        callback_ast::Union{Expr,Nothing},
+        dependent_bindings::Union{Dict{Symbol, <:DependentDNA},Nothing}
         ) where {Range<:AbstractRange}
 
         Nu = length(uRange)
@@ -45,13 +48,31 @@ mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: ParametricDep
             0,
             uRange,
             vRange,
-            color)
+            color,
+            nothing)
     end
 end
 
 _ParametricDependent_(self::ParametricSurfaceDependent)::ParametricDependent = return self._parametricDependent
 _RenderedDependent_(self::ParametricSurfaceDependent)::RenderedDependent = return _ParametricDependent_(self)._renderedDependent
 Base.string(self::ParametricSurfaceDependent) = return "ParametricSurface"
+
+function post_setup_parametric_dependent!(self::ParametricSurfaceDependent)
+    dep::ParametricDependent = _ParametricDependent_(self)
+   
+    n = width(self._uvValues) * height(self._uvValues)
+
+    Base.resize!(dep._stagingBuffer, n)
+    
+    self._normalsBuffer = MappedBuffer{Vec4}(; read = true, write = false)
+    reserve!(self._normalsBuffer, n, 0)
+    
+    # force creation of position buffer so that normal calculations can always rely on it
+    if dep._callbackAST === nothing
+        dep._outBuffer = MappedBuffer{Vec4}(; read = false, write = true)
+        reserve!(dep._outBuffer, n, 0)
+    end
+end
 
 evalCallbackDpReturn(self::ParametricSurfaceDependent,value,u,v) = self._uvValues[u,v] = Vec3D(value)
 evalCallbackDpReturn(self::ParametricSurfaceDependent,value::Tuple,u,v) = self._uvValues[u,v] = Vec3D(value...)
@@ -88,8 +109,8 @@ end
 function onNodeEval(self::ParametricSurfaceDependent)
     eval_callbacks!(self)
 
-    # TODO: GPU-side normal calculation
-    update_normals_cpu!(self)
+    # update_normals_cpu!(self)
+    update_normals_gpu!(self)
 end
 
 function eval_callbacks_cpu!(self::ParametricSurfaceDependent)
@@ -155,6 +176,64 @@ function update_normals_cpu!(self::ParametricSurfaceDependent)
         down  = self._uvValues[width(self._uvValues),height(self._uvValues)])
 end
 
+function update_normals_gpu!(self::ParametricSurfaceDependent)
+    h = height(self._uvValues)
+    w = width(self._uvValues)
+    n = h * w
+
+    dep::ParametricDependent = _ParametricDependent_(self)
+
+    if is_cpu_tessellated(self)
+        @assert dep._outBuffer !== nothing "parametric surface without out buffer (position buffer)"
+        
+        # first normal calc after GPU -> CPU fallback state
+        if !dep._outBuffer._write
+            dep._outBuffer._write = true
+            dep._outBuffer._read  = false
+            reserve!(dep._outBuffer, n, 0)
+        end
+
+        i = 1
+        for v in 1:h
+            for u in 1:w
+                dep._stagingBuffer[i] = Vec4F(self._uvValues[u, v], 0)
+                i += 1
+            end
+        end
+
+        copyto!(dep._outBuffer, dep._stagingBuffer)
+    end
+
+    normals_shader = getOpenGL(implicitApp)._surface_normals
+    activate(normals_shader) # TODO: use SPIRV
+    glUniform2i(normals_shader.uniforms["uvGridSize"], GLint(height(self._uvValues)), GLint(width(self._uvValues)))
+
+    bind_ssbo(dep._outBuffer, 0)
+    bind_ssbo(self._normalsBuffer, 1)
+
+    glDispatchCompute(div(w + 15, 16), div(h + 15, 16), 1)
+
+    glMemoryBarrier(GL_CLIENT_MAPPED_BUFFER_BARRIER_BIT)
+    fence = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0)
+    while true
+        waitReturn = glClientWaitSync(fence, GL_SYNC_FLUSH_COMMANDS_BIT, 1000000);
+        if waitReturn == GL_ALREADY_SIGNALED || waitReturn == GL_CONDITION_SATISFIED
+            break
+        elseif waitReturn == GL_WAIT_FAILED
+            @log "Failed to sync after dispatching surface normal calculation compute shader" ERR
+            glDeleteSync(fence)
+        end
+    end
+    glDeleteSync(fence)
+
+    copyto!(dep._stagingBuffer, 1, self._normalsBuffer._mapped, 1, n)
+
+    for v in 1:h, u in 1:w
+        v4 = dep._stagingBuffer[(v - 1) * w + u]
+        self._uvNormals[u, v] = Vec3D(v4.x, v4.y, v4.z)
+    end
+end
+
 # ? methods for GPU tessellation
 
 function pre_gpu_tess!(self::ParametricSurfaceDependent)
@@ -171,12 +250,13 @@ end
 
 function handle_gpu_tess_result!(self::ParametricSurfaceDependent)::Bool
     dep::ParametricDependent = _ParametricDependent_(self)
-    staging_buffer = data(dep._outBuffer)
+    
+    copyto!(dep._stagingBuffer, 1, dep._outBuffer._mapped, 1, dep._sampleCount)
     
     i::Int = 1
     for v in 1:height(self._uvValues)
         for u in 1:width(self._uvValues)
-            v4 = staging_buffer[i]
+            v4 = dep._stagingBuffer[i]
             v3 = Vec3F(v4.x, v4.y, v4.z)
 
             any(x -> isnan(x) || isinf(x), v3) && return false
@@ -188,14 +268,14 @@ function handle_gpu_tess_result!(self::ParametricSurfaceDependent)::Bool
     end
 
     # sync before gpu-side normal calculation
-    # glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT)
-
-    update_normals_cpu!(self)
+    glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT)
 
     return true
 end
 
 function try_transpile_tess_shader(self::ParametricSurfaceDependent)::Union{ShaderProgram,Nothing}
+    @time_cpu_begin GPUTessSetup CodeGen SurfaceWrapperCodeGen
+    
     dep::ParametricDependent = _ParametricDependent_(self)
 
     fn_data = splitdef(dep._callbackAST)
@@ -216,6 +296,7 @@ function try_transpile_tess_shader(self::ParametricSurfaceDependent)::Union{Shad
     end)
 
     dep._callbackAST = combinedef(fn_data)
+    @time_cpu_end GPUTessSetup CodeGen SurfaceWrapperCodeGen
 
     return try_transpile_tess_shader_base(dep._callbackAST, dep._dependentBindings, [(GPU_TESS_UV_GRID_SIZE_STR, IVec2), (GPU_TESS_UV_RANGE_STR, Vec4)])
 end

--- a/src/Dependents/surface.jl
+++ b/src/Dependents/surface.jl
@@ -1,10 +1,15 @@
+# uniform identifiers used in code gen / upload
+const GPU_TESS_UV_GRID_SIZE = :JG_TESS_UV_GRID_SIZE
+const GPU_TESS_UV_GRID_SIZE_STR = string(GPU_TESS_UV_GRID_SIZE)
+const GPU_TESS_UV_RANGE = :JG_TESS_UV_RANGE
+const GPU_TESS_UV_RANGE_STR = string(GPU_TESS_UV_RANGE)
 
 # ? ---------------------------------
 # ! ParametricSurfaceDependent
 # ? ---------------------------------
 
-mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: RenderedDependentDNA
-    _renderedDependent::RenderedDependent
+mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: ParametricDependentDNA
+    _parametricDependent::ParametricDependent
     
     _uvValues::FlatMatrix{Vec3D}
     _uvNormals::FlatMatrix{Vec3D}
@@ -21,13 +26,20 @@ mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: RenderedDepen
         uRange::Range,
         vRange::Range,
         color::UInt32,
+        callback_ast::Union{Expr,Nothing},dependent_bindings::Union{Dict{Symbol, <:DependentDNA},Nothing}
         ) where {Range<:AbstractRange}
 
-        rd = RenderedDependent(callback,dependents)
-        uvValues = FlatMatrix{Vec3D}(length(uRange),length(vRange))        
-        uvNormals = FlatMatrix{Vec3D}(length(uRange),length(vRange))
+        Nu = length(uRange)
+        Nv = length(vRange)
+        pd = if callback_ast !== nothing && dependent_bindings !== nothing
+            ParametricDependent(callback,dependents,callback_ast,dependent_bindings,Nu*Nv)
+        else
+            ParametricDependent(callback,dependents)
+        end
+        uvValues = FlatMatrix{Vec3D}(Nu,Nv)        
+        uvNormals = FlatMatrix{Vec3D}(Nu,Nv)
 
-        new{Range}(rd,
+        new{Range}(pd,
             uvValues,
             uvNormals,
             0,
@@ -37,7 +49,8 @@ mutable struct ParametricSurfaceDependent{Range<:AbstractRange} <: RenderedDepen
     end
 end
 
-_RenderedDependent_(self::ParametricSurfaceDependent)::RenderedDependent = return self._renderedDependent
+_ParametricDependent_(self::ParametricSurfaceDependent)::ParametricDependent = return self._parametricDependent
+_RenderedDependent_(self::ParametricSurfaceDependent)::RenderedDependent = return _ParametricDependent_(self)._renderedDependent
 Base.string(self::ParametricSurfaceDependent) = return "ParametricSurface"
 
 evalCallbackDpReturn(self::ParametricSurfaceDependent,value,u,v) = self._uvValues[u,v] = Vec3D(value)
@@ -73,6 +86,13 @@ end
 # YELLOW Thread
 # RED Thread
 function onNodeEval(self::ParametricSurfaceDependent)
+    eval_callbacks!(self)
+
+    # TODO: GPU-side normal calculation
+    update_normals_cpu!(self)
+end
+
+function eval_callbacks_cpu!(self::ParametricSurfaceDependent)
     for v in eachindex(self._vRange)
         for u in eachindex(self._uRange)
             uf::Float64 = self._uRange[u]
@@ -81,7 +101,9 @@ function onNodeEval(self::ParametricSurfaceDependent)
             evalCallbackDp(self;callbackParams = (uf,vf), returnParams = (u,v))
         end
     end
-    
+end
+
+function update_normals_cpu!(self::ParametricSurfaceDependent)
     for v in 2:(height(self._uvValues)-1)
         for u in 2:(width(self._uvValues)-1)
             setNormal(self,u,v)
@@ -131,7 +153,71 @@ function onNodeEval(self::ParametricSurfaceDependent)
     setNormal(self,width(self._uvValues),height(self._uvValues),
         right = self._uvValues[width(self._uvValues),height(self._uvValues)],
         down  = self._uvValues[width(self._uvValues),height(self._uvValues)])
+end
 
+# ? methods for GPU tessellation
+
+function pre_gpu_tess!(self::ParametricSurfaceDependent)
+    shader = _ParametricDependent_(self)._tessCompShader
+    @assert shader !== nothing "GPU tessellation pipeline invoked on CPU-tessellated parametric dependent"
+    # TODO: proper range upload
+    @assert (self._uRange isa StepRange || self._uRange isa StepRangeLen) &&
+            (self._vRange isa StepRange || self._vRange isa StepRangeLen) "GPU tessellation currently only supports StepRanges"
+
+    glUniform1ui(shader.uniforms[GPU_TESS_N_STR], GLuint(width(self._uvValues) * height(self._uvValues)))
+    glUniform2i(shader.uniforms[GPU_TESS_UV_GRID_SIZE_STR], GLint(height(self._uvValues)), GLint(width(self._uvValues)))
+    glUniform4f(shader.uniforms[GPU_TESS_UV_RANGE_STR], first(self._uRange), step(self._uRange), first(self._vRange), step(self._vRange))
+end
+
+function handle_gpu_tess_result!(self::ParametricSurfaceDependent)::Bool
+    dep::ParametricDependent = _ParametricDependent_(self)
+    staging_buffer = data(dep._outBuffer)
+    
+    i::Int = 1
+    for v in 1:height(self._uvValues)
+        for u in 1:width(self._uvValues)
+            v4 = staging_buffer[i]
+            v3 = Vec3F(v4.x, v4.y, v4.z)
+
+            any(x -> isnan(x) || isinf(x), v3) && return false
+            
+            evalCallbackDpReturn(self, v3, u, v)
+
+            i += 1
+        end
+    end
+
+    # sync before gpu-side normal calculation
+    # glMemoryBarrier(GL_SHADER_STORAGE_BARRIER_BIT)
+
+    update_normals_cpu!(self)
+
+    return true
+end
+
+function try_transpile_tess_shader(self::ParametricSurfaceDependent)::Union{ShaderProgram,Nothing}
+    dep::ParametricDependent = _ParametricDependent_(self)
+
+    fn_data = splitdef(dep._callbackAST)
+
+    if length(get(fn_data, :args, [])) < 2
+        @log "cannot transpile function with less than two arguments as a parametric surface callback" INFO
+        return nothing
+    end
+
+    u_varname = namify(fn_data[:args][1]) # first argument is the first parameter (u)
+    v_varname = namify(fn_data[:args][2]) # second argument is the second parameter (v)
+    deleteat!(fn_data[:args], 1:2)
+
+    # add code for calculating the u, v parameters GPU-side
+    pushfirst!(fn_data[:body].args, quote
+        $u_varname = JG_TESS_UV_RANGE[:x] + (Int32(JG_TESS_ID) % JG_TESS_UV_GRID_SIZE[:y]) * JG_TESS_UV_RANGE[:y]
+        $v_varname = JG_TESS_UV_RANGE[:z] + div(Int32(JG_TESS_ID), JG_TESS_UV_GRID_SIZE[:y]) * JG_TESS_UV_RANGE[:w]
+    end)
+
+    dep._callbackAST = combinedef(fn_data)
+
+    return try_transpile_tess_shader_base(dep._callbackAST, dep._dependentBindings, [(GPU_TESS_UV_GRID_SIZE_STR, IVec2), (GPU_TESS_UV_RANGE_STR, Vec4)])
 end
 
 # ? For Intersectable ParametricSurfaces.
@@ -223,17 +309,22 @@ Dependent2Observer(app::AppDNA,::ParametricSurfaceDependent)::ParametricSurfaceR
 function ParametricSurface(callback::Function,
                            uRange=range(0.0,1.0,50),vRange=range(0.0,1.0,50),
                            dependents::Vector{<:DependentDNA}=DependentDNA[],color_data::Union{Nothing,String}=nothing;
-                           color="g")
+                           color="g", enable_gpu_tessellation::Bool=false,
+                           callback_ast::Union{Expr,Nothing}=nothing,dependent_bindings::Union{Dict{Symbol,<:DependentDNA},Nothing}=nothing)
+    if !enable_gpu_tessellation
+        callback_ast = nothing
+        dependent_bindings = nothing
+    end 
     c = isnothing(color_data) ? get_color(color) : get_color(color_data)
-    Build!(ParametricSurfaceDependent(callback,dependents,uRange,vRange,c))
+    Build!(ParametricSurfaceDependent(callback,dependents,uRange,vRange,c,callback_ast,dependent_bindings))
 end
 
 macro ParametricSurface(callback::Expr,uRange,vRange,args...)
-    (positional_args, kw_args) = _parse_macro_arguments((:color_data,),(:color,), args...)
+    (positional_args, kw_args) = _parse_macro_arguments((:color_data,),(:color,:enable_gpu_tessellation), args...)
     callback = _validate_callback_expr(callback, 2)
     return _create_ctor_wrapper(callback, __module__, Juliagebra.ParametricSurface,
                                 positional_args,kw_args,
-                                (cb, deps) -> (cb, uRange, vRange, deps))
+                                (cb, deps) -> (cb, uRange, vRange, deps), true)
 end
 
 export ParametricSurface

--- a/src/GL/buffer.jl
+++ b/src/GL/buffer.jl
@@ -135,7 +135,7 @@ end
     if !self._read
         glGetNamedBufferSubData(self._id, 0, N * sizeof(T), out_vec)
     else
-        copyto!(out_vec, self)
+        copyto!(out_vec, 1, self._mapped, 1, N)
     end
 
     return out_vec
@@ -188,12 +188,6 @@ end
 function Base.copyto!(dest::MappedBuffer, src)
     @assert dest._write "trying to copy data to MappedBuffer with non-writeable mapping"
     copyto!(dest._mapped, src)
-    return dest
-end
-
-function Base.copyto!(dest, src::MappedBuffer)
-    @assert src._read "trying to copy data from MappedBuffer with non-readable mapping"
-    copyto!(dest, src._mapped)
     return dest
 end
 

--- a/src/GL/buffer.jl
+++ b/src/GL/buffer.jl
@@ -22,11 +22,16 @@ mutable struct MappedBuffer{T} <: BufferBase{T}
     _mapped::Vector{T}
     _sync::GLsync
 
-    function MappedBuffer{T}() where {T}
+    # these control GL_MAP_WRITE_BIT/GL_MAP_READ_BIT usage in MappedBuffer methods
+    _write::Bool
+    _read::Bool
+
+    function MappedBuffer{T}(; write::Bool = true, read::Bool = false) where {T}
         @assert isbitstype(T) "OpenGL requires bitstypes."
+        @assert write || read "OpenGL requires buffer mappings to be either readable, writeable or both."
         id = Ref{GLuint}()
         glCreateBuffers(1, id)
-        new{T}(id[], 0, Vector{T}(), C_NULL)
+        new{T}(id[], 0, Vector{T}(), C_NULL, write, read)
     end
 end
 
@@ -96,18 +101,18 @@ end
 # ? ---------------------------------
 
 @inline function reserve!(self::MappedBuffer{T}, count::Int, flags)::Bool where {T}
-    new_storage = _reserve!(self, count, GLbitfield(flags) | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT)
+    new_storage = _reserve!(self, count, GLbitfield(flags) | _map_flags(self))
     if new_storage
-        ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT)
+        ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), _map_flags(self))
         self._mapped = unsafe_wrap(Array, Ptr{T}(ptr), (length(self),); own = false)
     end
     return new_storage
 end
 
 @inline function upload!(self::MappedBuffer{T}, data::AbstractVector{T}, flags)::Bool where {T}
-    new_storage = _upload!(self, data, GLbitfield(flags) | GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT)
+    new_storage = _upload!(self, data, GLbitfield(flags) | _map_flags(self))
     if new_storage
-        ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT)
+        ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), _map_flags(self))
         self._mapped = unsafe_wrap(Array, Ptr{T}(ptr), (length(self),); own = false)
     end
     return new_storage
@@ -117,15 +122,49 @@ end
     if length(data) == 0 return false end
     glUnmapBuffer(self._id)
     glNamedBufferSubData(self._id, 0, length(data) * sizeof(T), data)
-    ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT)
+    ptr = glMapNamedBufferRange(self._id, 0, length(self) * sizeof(T), _map_flags(self))
     self._mapped = unsafe_wrap(Array, Ptr{T}(ptr), (length(self),); own = false)
     return false
 end
 
+@inline function data(self::MappedBuffer{T}, out_vec=Vector{T}())::Vector{T} where {T}
+    N = length(self)
+    Base.resize!(out_vec, N)
+    if N == 0 return out_vec end
+
+    if !self._read
+        glGetNamedBufferSubData(self._id, 0, N * sizeof(T), out_vec)
+    else
+        copyto!(out_vec, self)
+    end
+
+    return out_vec
+end
+
+@inline function data(self::MappedBuffer{T}, count::Int, offset::Int, out_vec=Vector{T}())::Vector{T} where {T}
+    @assert count <= length(self)
+    Base.resize!(out_vec, count)
+    if count == 0 return out_vec end
+
+    if !self._read
+        glGetNamedBufferSubData(self._id, offset * sizeof(T), count * sizeof(T), out_vec)
+    else
+        copyto!(out_vec, 1, self._mapped, offset + 1, count)
+    end
+
+    return out_vec
+end
+
 function Base.setindex!(self::MappedBuffer{T}, value, index::Int) where {T}
+    @assert self._write "trying to setindex! into MappedBuffer with non-writeable mapping"
     val_converted = convert(T, value)
     self._mapped[index] = val_converted
     return self
+end
+
+function Base.getindex(self::MappedBuffer{T}, index::Int)::T where {T}
+    @assert self._read "trying to getindex from MappedBuffer with non-readable mapping"
+    return self._mapped[index]
 end
 
 function Base.lock(self::MappedBuffer)
@@ -147,7 +186,14 @@ function Base.wait(self::MappedBuffer)
 end
 
 function Base.copyto!(dest::MappedBuffer, src)
+    @assert dest._write "trying to copy data to MappedBuffer with non-writeable mapping"
     copyto!(dest._mapped, src)
+    return dest
+end
+
+function Base.copyto!(dest, src::MappedBuffer)
+    @assert src._read "trying to copy data from MappedBuffer with non-readable mapping"
+    copyto!(dest, src._mapped)
     return dest
 end
 
@@ -250,4 +296,11 @@ end
     glNamedBufferStorage(self._id, bytes, data, flags)
     self._size = bytes
     return true
+end
+
+@inline function _map_flags(self::MappedBuffer{T})::GLbitfield where {T}
+    bits = GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT
+    self._read  && (bits |= GL_MAP_READ_BIT)
+    self._write && (bits |= GL_MAP_WRITE_BIT)
+    return bits
 end

--- a/src/Helpers/dependency_lookup.jl
+++ b/src/Helpers/dependency_lookup.jl
@@ -151,11 +151,11 @@ macro _collect_kw_args(kw_args, arg_defaults...)
 end
 
 function _validate_callback_expr(callback, arg_count::Integer)
-    if !MacroTools.isdef(callback)
+    if !isdef(callback)
         error("Expected function definition expression in 'callback' argument to $(_get_caller())")
     end
 
-    callback = MacroTools.longdef(callback)
+    callback = longdef(callback)
 
     # remove fn name
     if Meta.isexpr(callback.args[1], :call)
@@ -174,7 +174,7 @@ function _validate_callback_expr(callback, arg_count::Integer)
         error("Invalid number of arguments in callback definition passed to $(_get_caller()). Expected $arg_count, got $(length(cb_args)) instead.")
     end
 
-    arg_infos = map(MacroTools.splitarg, cb_args)
+    arg_infos = map(splitarg, cb_args)
     syms = Set{Symbol}()
     sizehint!(syms, length(cb_args))
     for (sym, type, slurp, default) in arg_infos
@@ -459,9 +459,9 @@ function _collect_free_vars(def::Expr, mod::Module)
     end
 
     def = macroexpand(mod, def)
-    @assert MacroTools.isdef(def) "Non function definition expression passed to collect_free_var_syms"
+    @assert isdef(def) "Non function definition expression passed to collect_free_var_syms"
 
-    def = MacroTools.longdef(def)
+    def = longdef(def)
 
     fn_scope = Set{Symbol}()
     _process_fn_sig!(def.args[1], fn_scope, Set{Symbol}(), walk!)
@@ -471,12 +471,13 @@ function _collect_free_vars(def::Expr, mod::Module)
 end
 
 """Helper for generating the code returned by macro ctors"""
-function _create_ctor_wrapper(callback, mod::Module, base_ctor, ctor_optional_args::Vector{Any}, ctor_kw_args::Dict{Symbol,Any}, get_ctor_args = tuple)
+function _create_ctor_wrapper(callback, mod::Module, base_ctor, ctor_optional_args::Vector{Any}, ctor_kw_args::Dict{Symbol,Any}, get_ctor_args = tuple, pass_gpu_tess_args::Bool = false)
     free_syms = _collect_free_vars(callback, mod)
 
     body = callback.args[2]
 
     gs_captured_deps = gensym(:captured_deps)
+    gs_dependent_bindings = gensym(:dependent_bindings)
     gs_callback_args = gensym(:callback_args)
     gs_callback_wrapper = gensym(:callback_wrapper)
 
@@ -490,6 +491,7 @@ function _create_ctor_wrapper(callback, mod::Module, base_ctor, ctor_optional_ar
 
             if $(esc(:(@isdefined($sym)))) && $(esc(sym)) isa DependentDNA
                 push!($gs_captured_deps, $(esc(sym)))
+                $gs_dependent_bindings[$(QuoteNode(sym))] = $(esc(sym))
                 $sym_gs = length($gs_captured_deps)
             end
         end)
@@ -504,15 +506,30 @@ function _create_ctor_wrapper(callback, mod::Module, base_ctor, ctor_optional_ar
         push!(inner_let_bindings.args, Expr(:(=), esc(sym), inner_let_rhs))
     end
 
-    base_ctor_args = [:($arg) for arg in get_ctor_args(gs_callback_wrapper, gs_captured_deps)]
+    base_ctor_args = [
+        (arg === gs_callback_wrapper || arg === gs_captured_deps) ? :($arg) : :($(esc(arg)))
+        for arg in get_ctor_args(gs_callback_wrapper, gs_captured_deps)
+    ]
     base_ctor_optional_args = [:($(esc(v))) for v in ctor_optional_args]
     base_ctor_kw_args = [:($(esc(k)) = $(esc(v))) for (k, v) in ctor_kw_args]
     base_ctor_call = :($base_ctor($(base_ctor_args...), $(base_ctor_optional_args...); $(base_ctor_kw_args...)))
+
+    if pass_gpu_tess_args
+        if !Meta.isexpr(base_ctor_call.args[2], :parameters)
+            insert!(base_ctor_call.args[2], 2, Expr(:parameters))
+        end
+
+        push!(base_ctor_call.args[2].args,
+            Expr(:kw, :callback_ast, QuoteNode(callback)),
+            Expr(:kw, :dependent_bindings, gs_dependent_bindings)
+        )
+    end
 
     base_cb_args = [esc(arg_sym) for arg_sym in callback.args[1].args]
 
     return quote
         $gs_captured_deps = Vector{DependentDNA}()
+        $gs_dependent_bindings = Dict{Symbol, DependentDNA}()
 
         $init_block
 

--- a/src/Helpers/transpilation.jl
+++ b/src/Helpers/transpilation.jl
@@ -1,0 +1,226 @@
+# identifiers used in generated tessellation shaders
+const GPU_TESS_N = :JG_TESS_N
+const GPU_TESS_N_STR = string(GPU_TESS_N)
+const GPU_TESS_POS_BUF = :JG_TESS_POS_BUFFER
+const GPU_TESS_POS_ARR = :JG_TESS_POS_ARRAY
+const GPU_TESS_CB = :JG_TESS_CALLBACK
+const GPU_TESS_ID = :JG_TESS_ID
+
+#=
+given a user-provided f : Params -> dependent_bindings -> Vec3 fn we roughly generate:
+
+uniform DepTy1 dep1;
+uniform DepTy2 dep2;
+
+<uniforms for params (geometry specific)>
+
+uniform uint n;                         // n ≡ JG_TESS_N
+
+layout(std430) (...) buffer PosBuffer   // PosBuffer ≡ JG_TESS_POS_BUFFER
+{
+    vec3 pos_arr[];                    // pos_arr ≡ JG_TESS_POS_ARRAY
+};
+
+vec3 f(uint id) {                       // f ≡ JG_TESS_CALLBACK
+    ...
+}
+
+void main() {
+    uint id = gl_GlobalInvocations.x;   // id ≡ JG_TESS_ID
+    if (id >= n)
+        return;
+
+    pos_arr[id + 1u] = f(id); // +1 to counteract transpiler's automatic -1 added for indexing conversion
+}
+=#
+
+_parse_curly(T::DataType)::Union{Expr,Symbol} = 
+        isempty(T.parameters) ? nameof(T) : Expr(:curly, nameof(T), _parse_curly.(T.parameters)...)
+
+# helper for base transpilation decorators reusable across pipelines
+function try_transpile_tess_shader_base(callback_ast::Expr, dependent_bindings::Dict{Symbol, <:DependentDNA},
+                                        extraUniforms::Vector{Tuple{String,DataType}}=Tuple{String,DataType}[])::Union{ShaderProgram,Nothing}
+    @time_cpu_begin GPUTessSetup CodeGen WrapperCodeGen
+
+    # since we can gratefully fall back to CPU callbacks if transpilation fails,
+    # we only log errors if explicitly requested (and as INFO), to avoid spamming the console
+    dbg::Bool = GPU_TESS_DEBUG_ARG in ARGS
+
+    if !isdef(callback_ast)
+        dbg && @log "non-function definition provided as callback" INFO
+        return nothing
+    end
+
+    translation_unit = Expr(:block)
+    top_cmpd = translation_unit.args
+
+    push!(top_cmpd, :(
+        @gl_buffer @gl_restrict @gl_writeonly @gl_layout(
+            std430, binding = $GPU_TESS_POS_BINDING_IDX,
+            struct $GPU_TESS_POS_BUF
+                $(GPU_TESS_POS_ARR)::Vector{Vec3}
+            end
+        ))
+    )
+
+    push!(top_cmpd, :(@gl_uniform global $GPU_TESS_N::UInt32))
+
+    for (uni_name, UniTy) in extraUniforms
+        type_expr = _parse_curly(UniTy)
+
+        push!(top_cmpd, :(@gl_uniform global $(Symbol(uni_name))::$type_expr))
+    end
+
+    for (sym, dep) in dependent_bindings
+        glsl_t = get_glsl_representation(typeof(dep))
+        if glsl_t == Nothing
+            dbg && @log "couldn't get GLSL reperesentation for dependent type: $(typeof(dep))" INFO
+        end
+
+        glsl_t_expr = _parse_curly(glsl_t)
+        push!(top_cmpd, :(@gl_uniform global $sym::$glsl_t_expr))
+    end
+
+    global implicitApp
+    implicitApp !== nothing && append!(top_cmpd, implicitApp._cb_helper_asts)
+
+    fn_data::Dict{Symbol,Any} = splitdef(callback_ast)
+
+    fn_data[:name] = GPU_TESS_CB
+
+    # if fn has explicit return type, it's currently overwritten
+    fn_data[:rtype] = :Vec3F
+
+    # args, kwargs and whereparams are stripped manually for now
+    fn_data[:kwargs] = []
+    fn_data[:whereparams] = ()
+    delete!(fn_data, :params) # old Julia type param syntax
+
+    fn_data[:args] = [:($GPU_TESS_ID::UInt32)]
+
+    push!(top_cmpd, combinedef(fn_data))
+
+    main_body = Expr(:block,
+        :($GPU_TESS_ID = gl_GlobalInvocationID[:x]),
+        :(
+            if $GPU_TESS_ID >= $GPU_TESS_N
+                return
+            end
+        ),
+        :($GPU_TESS_POS_ARR[$GPU_TESS_ID + UInt32(1)] = JG_TESS_CALLBACK($GPU_TESS_ID))
+    )
+
+    main_fn = combinedef(
+        Dict(
+            :name => :main,
+            :args => Any[],
+            :kwargs => Any[],
+            :whereparams => (),
+            :rtype => :Nothing,
+            :body => main_body
+        )
+    )
+
+    push!(top_cmpd, main_fn)
+
+    @time_cpu_end GPUTessSetup CodeGen WrapperCodeGen
+
+    @time_cpu_begin GPUTessSetup CodeGen Transpilation
+
+    # TODO: single global config handle in App
+    cfg = ConfigHandle()
+    
+    # 0 cg indent saves us from some unnecessary spacing generation and copy
+    set_config_opts!(cfg; target_version="460 core", code_gen_indent=UInt16(0), local_size=UInt32.((GPU_TESS_LOCAL_SIZE, 1, 1)))
+
+    if dbg
+        println("code passed to transpiler:")
+        println(translation_unit)
+    end
+    
+    pipe = Pipe()
+    glsl_code::Union{String,Nothing} =
+        try
+            # TODO: this approach could probably be improved
+            redirect_stderr(pipe) do
+                transpile(translation_unit; run_benchmarks=dbg, cfg)
+            end
+        catch ex
+            if dbg
+                @log "an unexpected error occured during transpilation, see stderr for details" INFO
+                println(stderr, ex)
+            end
+
+            nothing
+        finally
+            close(pipe.in)
+        end
+    @time_cpu_end GPUTessSetup CodeGen Transpilation
+
+    stderr_output = read(pipe.out, String)
+    close(pipe.out)
+
+    if glsl_code === nothing || isempty(glsl_code)
+        dbg && @log "callback code couldn't be transpiled" INFO
+
+        if dbg && !isempty(stderr_output)
+            @log "the transpiler printed errors, see stderr for details" INFO
+            println(stderr, stderr_output)
+        end
+
+        return nothing
+    end
+
+    if dbg
+        @log "successful transpilation, result printed to stdout" INFO
+        println(glsl_code)
+    end
+
+    # this is intentionally flagged in non-dbg mode as well
+    if !isempty(stderr_output)
+        @log "transpilation seems to have finished successfully, but the lib printed to stderr during execution:" WARN
+        @log stderr_output INFO
+    end
+
+    @time_cpu_begin GPUTessSetup CodeGen ShaderCreation
+    # creates unique file in default temp directory
+    path = tempname() * ".comp"
+    sp = open(path, "w") do io
+        write(io, glsl_code)
+        close(io)
+
+        return try
+            sp = ShaderProgram([path], [GPU_TESS_N_STR, first.(extraUniforms)..., string.(collect(keys(dependent_bindings)))...])
+
+            if sp.id != GLuint(0)
+                sp
+            else
+                dbg && @log "couldn't create ShaderProgram from generated code"
+                nothing
+            end
+        catch ex
+            if dbg
+                @log "error thrown while creating ShaderProgram from generated code, exception printed to stderr" INFO
+                println(stderr, ex)
+            end
+
+            nothing
+        end
+    end
+    @time_cpu_end GPUTessSetup CodeGen ShaderCreation
+
+    return sp
+end
+
+precompile(try_transpile_tess_shader_base, (Expr,Dict{Symbol, <:DependentDNA},Vector{Tuple{String,DataType}}))
+
+macro callback_helper(fn::Expr)
+    @assert isdef(fn) "@callback_helper placed before non-function AST node"
+
+    global implicitApp
+    implicitApp !== nothing && push!(implicitApp._cb_helper_asts, fn)
+
+    return esc(fn)
+end
+
+export @callback_helper

--- a/src/Helpers/transpilation.jl
+++ b/src/Helpers/transpilation.jl
@@ -127,21 +127,16 @@ function try_transpile_tess_shader_base(callback_ast::Expr, dependent_bindings::
 
     @time_cpu_begin GPUTessSetup CodeGen Transpilation
 
-    # TODO: single global config handle in App
-    cfg = ConfigHandle()
-    
-    # 0 cg indent saves us from some unnecessary spacing generation and copy
-    set_config_opts!(cfg; target_version="460 core", code_gen_indent=UInt16(0), local_size=UInt32.((GPU_TESS_LOCAL_SIZE, 1, 1)))
+    cfg = implicitApp._transpiler_config
 
     if dbg
         println("code passed to transpiler:")
         println(translation_unit)
     end
-    
+
     pipe = Pipe()
     glsl_code::Union{String,Nothing} =
         try
-            # TODO: this approach could probably be improved
             redirect_stderr(pipe) do
                 transpile(translation_unit; run_benchmarks=dbg, cfg)
             end

--- a/src/Juliagebra.jl
+++ b/src/Juliagebra.jl
@@ -18,7 +18,8 @@ using DataStructures
 using ThreadPinning
 using BitFlags
 #pinthreads(:cores)
-import MacroTools
+using MacroTools
+using ShaderTranspiler
 
 include("profiling.jl")
 include("performance_metrics.jl")
@@ -103,6 +104,8 @@ include("opengl_data.jl")
 # ? ---------------------------------
 
 include("Dependents/dependents.jl")
+
+include("Helpers/transpilation.jl") # ! needs dependents for type conversions
 
 include("Widgets/points_window.jl")
 include("Widgets/curves_window.jl")

--- a/src/Widgets/curves_window.jl
+++ b/src/Widgets/curves_window.jl
@@ -47,7 +47,7 @@ end
 
 function renderContent(self::CurvesWindow)
     col_flags = CImGui.ImGuiTableColumnFlags_WidthFixed
-    if !CImGui.BeginTable("curves_tbl", 4,
+    if !CImGui.BeginTable("curves_tbl", 5,
             CImGui.ImGuiTableFlags_Borders | CImGui.ImGuiTableFlags_RowBg |
             CImGui.ImGuiTableFlags_ScrollY)
         return
@@ -58,6 +58,7 @@ function renderContent(self::CurvesWindow)
     CImGui.TableSetupColumn("Colors", col_flags, 250.0) 
     CImGui.TableSetupColumn("Width",  col_flags, 90.0 )
     CImGui.TableSetupColumn("Style",  col_flags, 65.0 )
+    CImGui.TableSetupColumn("Tess",   col_flags, 65.0 )
     CImGui.TableHeadersRow()
 
     for node in getNodes(self._model._graph)
@@ -159,6 +160,10 @@ function renderContent(self::CurvesWindow)
             node._style = _CURVE_STYLE_VALUES[style_ref[] + 1]
             set_style(self._renderer,node)
         end
+
+        # --- Tessellation Type Column ---
+        CImGui.TableNextColumn()
+        CImGui.Text(is_gpu_tessellated(node) ? "GPU" : "CPU")
     end
 
     CImGui.EndTable()

--- a/src/Widgets/surfaces_window.jl
+++ b/src/Widgets/surfaces_window.jl
@@ -21,7 +21,7 @@ end
 
 function renderContent(self::SurfacesWindow)
     col_flags = CImGui.ImGuiTableColumnFlags_WidthFixed
-    if !CImGui.BeginTable("surfaces_tbl", 2,
+    if !CImGui.BeginTable("surfaces_tbl", 3,
             CImGui.ImGuiTableFlags_Borders | CImGui.ImGuiTableFlags_RowBg |
             CImGui.ImGuiTableFlags_ScrollY)
         return
@@ -30,6 +30,7 @@ function renderContent(self::SurfacesWindow)
     CImGui.TableSetupScrollFreeze(0, 1)
     CImGui.TableSetupColumn("ID",          col_flags, 28.0)
     CImGui.TableSetupColumn("Color")
+    CImGui.TableSetupColumn("Tess")
     CImGui.TableHeadersRow()
 
     for node in getNodes(self._model._graph)
@@ -49,6 +50,9 @@ function renderContent(self::SurfacesWindow)
             node._color = new_color
             set_color(self._renderer,node)
         end
+
+        CImGui.TableNextColumn()
+        CImGui.Text(is_gpu_tessellated(node) ? "GPU" : "CPU")
     end
 
     CImGui.EndTable()

--- a/src/app.jl
+++ b/src/app.jl
@@ -27,6 +27,8 @@ mutable struct App <: AppDNA
     _delta_time::Float64
     _vsync_state::Int32
 
+    _cb_helper_asts::Vector{Expr}
+
     function App(
         name::String="Juliagebra",
         width::Int32=Int32(1280),
@@ -55,10 +57,12 @@ mutable struct App <: AppDNA
         delta_time = 0.0
         vsync_state = Int32(1)
 
+        cb_helper_asts = Expr[]
+
         new(
             glfw,inputs,opengl,imgui,
             nothing,nothing,cam,manipulator,
-            optimizer,starter,commander,model,false,asset_watcher,hovered,delta_time,vsync_state)
+            optimizer,starter,commander,model,false,asset_watcher,hovered,delta_time,vsync_state,cb_helper_asts)
     end
 end
 

--- a/src/app.jl
+++ b/src/app.jl
@@ -28,6 +28,7 @@ mutable struct App <: AppDNA
     _vsync_state::Int32
 
     _cb_helper_asts::Vector{Expr}
+    _transpiler_config::ConfigHandle
 
     function App(
         name::String="Juliagebra",
@@ -58,11 +59,16 @@ mutable struct App <: AppDNA
         vsync_state = Int32(1)
 
         cb_helper_asts = Expr[]
+    
+        transpiler_config = ConfigHandle()
+        set_config_opts!(transpiler_config; target_version="460 core", code_gen_indent=UInt16(0),
+                         local_size=UInt32.((GPU_TESS_LOCAL_SIZE, 1, 1)))
 
         new(
             glfw,inputs,opengl,imgui,
             nothing,nothing,cam,manipulator,
-            optimizer,starter,commander,model,false,asset_watcher,hovered,delta_time,vsync_state,cb_helper_asts)
+            optimizer,starter,commander,model,false,asset_watcher,hovered,delta_time,vsync_state,
+            cb_helper_asts,transpiler_config)
     end
 end
 

--- a/src/opengl_data.jl
+++ b/src/opengl_data.jl
@@ -46,6 +46,7 @@ mutable struct OpenGLData
     _highlighter::Pipeline
     _buffer_clear::Pipeline
     _grid::Pipeline
+    _surface_normals::ShaderProgram
 
     # ! Main FBO objects
     _rgbaTexture::Texture2D
@@ -128,6 +129,7 @@ mutable struct OpenGLData
             vert = spv"postprocess/grid.vert",
             frag = spv"postprocess/grid.frag"
         )
+        surface_normals = ShaderProgram(["surface_normals.comp"], ["uvGridSize"])
 
         depth_stencil = Texture2D(window.width,window.height,GL_DEPTH24_STENCIL8,GL_DEPTH_STENCIL,GL_UNSIGNED_INT_24_8)
         depth_stencil_behind_opaque = Texture2D(window.width,window.height,GL_DEPTH24_STENCIL8,GL_DEPTH_STENCIL,GL_UNSIGNED_INT_24_8)
@@ -190,7 +192,7 @@ mutable struct OpenGLData
         camPos = Vec3F(0.0,0.0,0.0)
 
         self = new(window,profiler,passes,cpu_stopwatch,pipeline_loader,observers,renderers,
-            transparent_color_combiner,transparent_id_combiner,highlighter,buffer_clear,grid,
+            transparent_color_combiner,transparent_id_combiner,highlighter,buffer_clear,grid,surface_normals,
             rgba,id,depth_stencil,depth_stencil_behind_opaque,accum,reveal,
             opaqueFBO,behindOpaqueFBO,transparentFBO,
             ubo,pixel_buffer_dist,pixel_buffer_col,pixel_buffer_id,empty_vao,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,5 +3,5 @@ using Test
 const RUN_MODEL_TESTS = true
 const RUN_MACRO_TESTS = true
 
-RUN_MACRO_TESTS ? include("model_tests.jl") : nothing
+RUN_MODEL_TESTS ? include("model_tests.jl") : nothing
 RUN_MACRO_TESTS ? include("macro_tests.jl") : nothing


### PR DESCRIPTION
Brought over and refined the previous implementation to the new architecture. It only supports the single threaded, single frame scheduling for now, but already handles thread_affinity properly for the future.

The GPU-side tessellation of both curves and surfaces should work now, along with compute-based normal calculation for surfaces (for both GPU and CPU tessellated surfaces). The `m49_torus_knot` and `m50_bryant_kusner` examples demonstrate simple CPU vs GPU tessellation over (unnecessarily) dense ranges. They also demonstrate the usage of the callback_helper macro, which is a quick, partial solution to the foreign function AST problem until proper AST tracking is implemented. GPU tessellation is an opt-in feature for now, via the `enable_gpu_tessellation` argument of the `ParametricCurve` and `ParametricSurface` constructors.

The PR also extends `MappedBuffer` with explicit control over read/write mapping (defaulting to the previous write-only setting when not specified, so that previous code is not affected by this).

Currently supported dependent types on the GPU (as dependencies):
- Point
- Slider
- Stepper
- Toggle

Related issues:
closes #85, closes #116, closes #86