### PR TITLE
Improved gizmo movement

### DIFF
--- a/assets/shaders/src/renderers/gizmo/gizmo.geom
+++ b/assets/shaders/src/renderers/gizmo/gizmo.geom
@@ -12,10 +12,21 @@ layout(location = 0) noperspective out vec4 segment_SDF_field_g_out; // x,y,lenX
 layout(location = 1) flat          out vec3 color_g_out;
 layout(location = 2) flat          out uint id_g_out;
 
+layout(constant_id = 0) const bool CORNER_GIZMO = false;
 layout(constant_id = 1) const float CONTENT_SCALE = 1.0;
+layout(std140, binding = 0) uniform Gizmo_UBO_Axis {
+    vec4 center_axis;
+};
+layout(std140, binding = 1) uniform Gizmo_UBO_Size {
+    float gizmo_length;
+    float gizmo_thickness;
+};
 
 void main() {
-    const float WIDTH = 5.5 * CONTENT_SCALE;
+    float WIDTH = 5.5 * CONTENT_SCALE;
+    if (!CORNER_GIZMO) {
+        WIDTH *= gizmo_thickness;
+    }
     color_g_out = color_v_out[0];
     id_g_out    = id_v_out[0];
 
@@ -43,8 +54,7 @@ void main() {
     vec2 AB_dir = normalize(B - A);
     vec2 AB_N = vec2(-AB_dir.y, AB_dir.x);
 
-
-    float len_X = WIDTH +  WIDTH;
+    float len_X = WIDTH + WIDTH;
     float len_Y = segment_len + WIDTH + WIDTH;
 
 

--- a/assets/shaders/src/renderers/gizmo/gizmo.vert
+++ b/assets/shaders/src/renderers/gizmo/gizmo.vert
@@ -4,8 +4,12 @@
 
 layout(constant_id = 0) const bool CORNER_GIZMO = false;
 layout(constant_id = 1) const float CONTENT_SCALE = 1.0;
-layout(std140, binding = 0) uniform Gizmo_UBO {
+layout(std140, binding = 0) uniform Gizmo_UBO_Axis {
     vec4 center_axis;
+};
+layout(std140, binding = 1) uniform Gizmo_UBO_Size {
+    float gizmo_length;
+    float gizmo_thickness;
 };
 
 const vec3 vertices[6] = vec3[6](vec3(1,0,0),vec3(-1,0,0),vec3(0,1,0),vec3(0,-1,0),vec3(0,0,1),vec3(0,0,-1));
@@ -32,7 +36,7 @@ void main(){
     } else {
         gizmoCenter = center_axis.xyz;
         centerClip = VP * vec4(gizmoCenter, 1.0);
-        gizmoScale = (centerClip.w / P[0][0]) * (gizmoPixelLength / width());
+        gizmoScale = (centerClip.w / P[0][0]) * (gizmoPixelLength * gizmo_length / width());
         
         for (int i = 0; i < 6; ++i) {
             vec4 proj_point = VP * vec4(vertices[i] * gizmoScale + gizmoCenter, 1.0); 

--- a/src/Juliagebra.jl
+++ b/src/Juliagebra.jl
@@ -88,7 +88,6 @@ include("Widgets/dock.jl")
 include("Widgets/window.jl")
 include("Widgets/reset_widget.jl")
 include("Widgets/options_widget.jl")
-include("Widgets/coordinates_widget.jl")
 
 include("Widgets/console.jl")
 include("Widgets/named_window.jl")
@@ -98,6 +97,8 @@ include("Widgets/Windows/options_window.jl")
 
 include("Renderers/renderers.jl")
 include("opengl_data.jl")
+
+include("Widgets/coordinates_widget.jl")
 
 # ? ---------------------------------
 # ! Dependents

--- a/src/Juliagebra.jl
+++ b/src/Juliagebra.jl
@@ -88,6 +88,7 @@ include("Widgets/dock.jl")
 include("Widgets/window.jl")
 include("Widgets/reset_widget.jl")
 include("Widgets/options_widget.jl")
+include("Widgets/coordinates_widget.jl")
 
 include("Widgets/console.jl")
 include("Widgets/named_window.jl")

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -90,29 +90,22 @@ function draw_ui(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
     return nothing
 end
 
-function _screen24(v::Vec4F)::Vec2F
-    x = (v.x / v.w)
-    y = (v.y / v.w)
-    return Vec2F(x, y)
-end
+function _seg2segSqDistParams(p::Vec3D, v::Vec3D, q::Vec3D, w::Vec3D) :: Tuple{Float64,Float64,Float64}
+    r  = q - p
 
-function screenVecs(origin, axis, x, y, width, height, vp)
-    screenOrigin = vp * Vec4F(origin, 1.0)
-    screenOrigin = _screen24(screenOrigin)
+    # v2, w2 : magnitudes^2
+    # vw : parallellity
+    v2 = dot(v,v); w2 = dot(w,w); vw = dot(v,w)
 
-    screenAxis = vp * Vec4F(axis, 1.0)
-    screenAxis = _screen24(screenAxis)
-
-    screenMouse = Vec2F((x / width) * 2.0 - 1.0, (y / height) * 2.0 - 1.0)
-
-    return (screenOrigin, screenAxis, screenMouse)
-end
-
-function _getAxisClampedT(axis_2d::Vec2F, mouse_2d::Vec2F)::Float32
-    partOne = axis_2d.x * mouse_2d.x + axis_2d.y * mouse_2d.y
-    partDiv = axis_2d.x * axis_2d.x + axis_2d.y * axis_2d.y
-    if partDiv < 1e-6 return 0.0f0 end
-    return partOne / partDiv
+	D  = v2*w2 - vw*vw # ‖v×w‖²
+    a1 = dot(v,r); a2 = dot(w,r); a3 = dot(cross(v,w), r)
+	
+    t  = ( w2*a1 - vw*a2 ) / D
+    s  = ( vw*a1 - v2*a2 ) / D
+	
+    d2 = a3*a3 / D
+	
+    return (d2, t, s)
 end
 
 function on_gizmo_left_click!(app)::Bool
@@ -168,26 +161,19 @@ function on_gizmo_drag!(app, event)::Bool
     end
 
     selected_axis_idx = gizmo.axes == AXIS_Y ? 2 : (gizmo.axes == AXIS_Z ? 3 : 1)
-    
-    vp, _, _ = get_matrices(app._cam)
-    origin = Vec3F(gizmo.position)
-    axis_vector = gizmo.id_to_axis[selected_axis_idx] + origin
-    
-    screen_origin, screen_axis, screen_mouse = screenVecs(origin, axis_vector, event.x, event.y, app._glfw.width, app._glfw.height, vp)
-    t = _getAxisClampedT(screen_axis - screen_origin, screen_mouse - screen_origin)
-    
-    if norm(screen_axis - screen_origin) >= 0.01f0
-        gizmo.position = Vec3D(origin + (axis_vector - origin) * t)
-        
-        if gizmo.selected > 3
-            p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
-            if p._coord != gizmo.position
-                p._coord = gizmo.position
-                # ? schedule for evalGraph
-                schedule(getModel(app),p)
-            end
+
+    ray = get_ray(app, event.x, event.y)
+    (_, _, s) = _seg2segSqDistParams(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.id_to_axis[selected_axis_idx]))
+
+    gizmo.position = Vec3D(gizmo.position + gizmo.id_to_axis[selected_axis_idx] * s)
+    if gizmo.selected > 3
+        p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
+        if p._coord != gizmo.position
+            p._coord = gizmo.position
+            # ? schedule for evalGraph
+            schedule(getModel(app),p)
         end
-    end 
-    
+    end
+
     return true
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -203,6 +203,16 @@ function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     end
 end
 
+function update_position!(app, point)
+    gizmo = app._opengl._renderers.gizmo
+    if (gizmo.axes != 0)
+        p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
+        if (isa(p, PointDependent) && point == p)
+            gizmo.position = p._coord
+        end
+    end
+end
+
 function on_gizmo_left_click!(app)::Bool
     gizmo = app._opengl._renderers.gizmo
     if 0 < app._hovered <= 3 # TODO: only when not moving yet

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -26,19 +26,22 @@ mutable struct GizmoRenderer
     selectedAxis::UInt32
     lastMousePosition::Tuple{Float64,Float64}
 
-    ubo::MappedBuffer{Vec4F}
+    # ? 3 floats for position, 4th float for axes visibility
+    ubo_axis::MappedBuffer{Vec4F}
+    # ? 1 float for length + 1 float for thickness
+    ubo_size::MappedBuffer{Float32}
     empty_vao::VertexArray
 
     function GizmoRenderer(loader::PipelineLoader,content_scale::Float32)
         corner_gizmo = create_graphics_pipeline!(loader;
             vert = (spv"renderers/gizmo/gizmo.vert",Tuple{GLuint,GLuint}[(0,1),(1,reinterpret(GLuint,content_scale))]),
-            geom = (spv"renderers/gizmo/gizmo.geom",Tuple{GLuint,GLuint}[(1,reinterpret(GLuint,content_scale))]),
+            geom = (spv"renderers/gizmo/gizmo.geom",Tuple{GLuint,GLuint}[(0,1),(1,reinterpret(GLuint,content_scale))]),
             frag = spv"renderers/gizmo/gizmo.frag"
         )
 
         move_gizmo = create_graphics_pipeline!(loader;
             vert = (spv"renderers/gizmo/gizmo.vert",Tuple{GLuint,GLuint}[(0,0),(1,reinterpret(GLuint,content_scale))]),
-            geom = (spv"renderers/gizmo/gizmo.geom",Tuple{GLuint,GLuint}[(1,reinterpret(GLuint,content_scale))]),
+            geom = (spv"renderers/gizmo/gizmo.geom",Tuple{GLuint,GLuint}[(0,0),(1,reinterpret(GLuint,content_scale))]),
             frag = spv"renderers/gizmo/gizmo.frag"
         )
         position = Vec3D(0.0)
@@ -52,14 +55,16 @@ mutable struct GizmoRenderer
         selectedAxis = UInt32(0)
         lastMousePosition = (Float64(0), Float64(0))
 
-        ubo = MappedBuffer{Vec4F}()
-        reserve!(ubo, 1, 0)
+        ubo_axis = MappedBuffer{Vec4F}()
+        reserve!(ubo_axis, 1, 0)
+        ubo_size = MappedBuffer{Float32}()
+        reserve!(ubo_size, 2, 0)
 
         empty_vao = VertexArray()
         return new(
             corner_gizmo,move_gizmo,position,initial_pos_diff,axes,
             initial_constraints,move,id_to_axis,selected,selectedAxis,lastMousePosition,
-            ubo,empty_vao
+            ubo_axis,ubo_size,empty_vao
         )
     end
 end
@@ -72,19 +77,22 @@ function reset!(renderer::GizmoRenderer)::Nothing
 end
 
 function destroy!(renderer::GizmoRenderer)::Nothing
-    destroy!(renderer.ubo)
+    destroy!(renderer.ubo_axis)
+    destroy!(renderer.ubo_size)
     return nothing
 end
 
 function pre_draw(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
     if renderer.axes == AXIS_NONE return nothing end
-    wait(renderer.ubo)
-    renderer.ubo[1] = Vec4F(
+    wait(renderer.ubo_axis)
+    renderer.ubo_axis[1] = Vec4F(
         Float32(renderer.position[1]),
         Float32(renderer.position[2]),
         Float32(renderer.position[3]),
         reinterpret(Float32, renderer.axes)
     )
+    renderer.ubo_size[1] = Float32(0.5)
+    renderer.ubo_size[2] = Float32(2.0)
     return nothing
 end
 
@@ -95,10 +103,12 @@ function draw_ui(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
 
     if renderer.axes == AXIS_NONE return nothing end
 
-    bind_ubo(renderer.ubo, 0)
+    bind_ubo(renderer.ubo_axis, 0)
+    bind_ubo(renderer.ubo_size, 1)
     activate(renderer.move_gizmo)
     glDrawArrays(GL_LINES, 0, 12)
-    lock(renderer.ubo)
+    lock(renderer.ubo_axis)
+    lock(renderer.ubo_size)
 
     return nothing
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -10,6 +10,7 @@ const AXIS_TO_VECTOR = Dict{UInt32,Vec3F}(
     AXIS_Y => Vec3F(0,1,0),
     AXIS_Z => Vec3F(0,0,1),
 )
+const ALL_AXES = UInt32[AXIS_X, AXIS_Y, AXIS_Z]
 
 mutable struct GizmoRenderer
     corner_gizmo::Pipeline
@@ -22,6 +23,7 @@ mutable struct GizmoRenderer
     id_to_axis::Tuple{Vec3F,Vec3F,Vec3F}
     selected::UInt32
     selectedAxis::UInt32
+    lastMousePosition::Tuple{Float64,Float64}
 
     ubo::MappedBuffer{Vec4F}
     empty_vao::VertexArray
@@ -46,6 +48,7 @@ mutable struct GizmoRenderer
         id_to_axis = (Vec3F(1,0,0), Vec3F(0,1,0), Vec3F(0,0,1))
         selected = UInt32(0)
         selectedAxis = UInt32(0)
+        lastMousePosition = (Float64(0), Float64(0))
 
         ubo = MappedBuffer{Vec4F}()
         reserve!(ubo, 1, 0)
@@ -53,7 +56,7 @@ mutable struct GizmoRenderer
         empty_vao = VertexArray()
         return new(
             corner_gizmo,move_gizmo,position,axes,
-            initial_constraints,move,id_to_axis,selected,selectedAxis,
+            initial_constraints,move,id_to_axis,selected,selectedAxis,lastMousePosition,
             ubo,empty_vao
         )
     end
@@ -115,7 +118,6 @@ function _seg2segSqDistParams(p::Vec3D,v::Vec3D,q::Vec3D,w::Vec3D)::Tuple{Float6
 	
     return (d2, t, s)
 end
-
 function _closestPointOnAxis(eye::Vec3D, ray::Vec3D, position::Vec3D, axis_vector::Vec3D)::Vec3D
     (_, _, s) = _seg2segSqDistParams(eye, ray, position, axis_vector)
     return Vec3D(position + axis_vector * s)
@@ -126,12 +128,40 @@ function _planeLineIntersection(eye::Vec3D, ray::Vec3D, position::Vec3D, normal_
     return PrimitiveToPrimitiveIntersection(line, plane)
 end
 
+function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
+    ray = get_ray(app, mouseX, mouseY)
+    newPoint = Vec3D(0)
+    
+    if (any(a -> a == gizmo.axes, ALL_AXES))
+        axis_vector = AXIS_TO_VECTOR[gizmo.axes]
+        newPoint = _closestPointOnAxis(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(axis_vector))
+    else
+        for axis in ALL_AXES
+            if (gizmo.axes & axis == 0)
+                newPoint = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
+                break
+            end
+        end
+    end
+
+    gizmo.position = newPoint
+    if gizmo.selected > 3
+        p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
+        if p._coord != gizmo.position
+            p._coord = gizmo.position
+            # ? schedule for evalGraph
+            schedule(getModel(app),p)
+        end
+    end
+end
+
 function on_gizmo_left_click!(app)::Bool
     gizmo = app._opengl._renderers.gizmo
     if 0 < app._hovered <= 3 # TODO: only when not moving yet
-        axes_map = UInt32[AXIS_X, AXIS_Y, AXIS_Z]
+        axes_map = ALL_AXES
         gizmo.axes = axes_map[app._hovered]
         gizmo.move = true
+        _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
         app._scene_change = true
         return true
     end
@@ -174,38 +204,12 @@ end
 
 function on_gizmo_drag!(app, event)::Bool
     gizmo = app._opengl._renderers.gizmo
+    gizmo.lastMousePosition = (event.x, event.y)
     if !gizmo.move || (gizmo.axes == AXIS_NONE && gizmo.selectedAxis == AXIS_NONE)
         return false
     end
 
-    ray = get_ray(app, event.x, event.y)
-    
-    newPoint = Vec3D(0,0,0)
-    if (gizmo.axes == AXIS_X || gizmo.axes == AXIS_Y || gizmo.axes == AXIS_Z)
-        axis_vector = AXIS_TO_VECTOR[gizmo.axes]
-        newPoint = _closestPointOnAxis(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(axis_vector))
-    else
-        normal_vector = Vec3F(0,0,0)
-        for axis in [AXIS_X, AXIS_Y, AXIS_Z]
-            if (gizmo.axes & axis == 0)
-                normal_vector = AXIS_TO_VECTOR[axis]
-                break
-            end
-        end
-        newPoint = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(normal_vector))
-        println(newPoint)
-    end
-
-    gizmo.position = newPoint
-    if gizmo.selected > 3
-        p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
-        if p._coord != gizmo.position
-            p._coord = gizmo.position
-            # ? schedule for evalGraph
-            schedule(getModel(app),p)
-        end
-    end
-
+    _move_gizmo!(app, gizmo, event.x, event.y)
     return true
 end
 
@@ -218,6 +222,7 @@ function on_gizmo_drag_axis_start!(app, axis)::Bool
     gizmo.selectedAxis |= axis
     gizmo.axes = gizmo.selectedAxis
     gizmo.move = true
+    _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
     
     app._scene_change = true
     return true

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -11,7 +11,7 @@ const AXIS_TO_VECTOR = Dict{UInt32,Vec3F}(
     AXIS_Z => Vec3F(0,0,1),
 )
 const ALL_AXES = UInt32[AXIS_X, AXIS_Y, AXIS_Z]
-const MIN_VIEW_ANGLE_DIFF::Float32 = abs(sin(deg2rad(5.0)))
+const MIN_VIEW_ANGLE_DIFF::Float32 = abs(sin(deg2rad(2.0)))
 
 mutable struct GizmoRenderer
     corner_gizmo::Pipeline

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -11,6 +11,7 @@ const AXIS_TO_VECTOR = Dict{UInt32,Vec3F}(
     AXIS_Z => Vec3F(0,0,1),
 )
 const ALL_AXES = UInt32[AXIS_X, AXIS_Y, AXIS_Z]
+const MIN_VIEW_ANGLE_DIFF::Float32 = abs(sin(deg2rad(5.0)))
 
 mutable struct GizmoRenderer
     corner_gizmo::Pipeline
@@ -22,6 +23,7 @@ mutable struct GizmoRenderer
     
     initial_constraints::UInt32
     move::Bool
+    first_move::Bool
     id_to_axis::Tuple{Vec3F,Vec3F,Vec3F}
     selected::UInt32
     selectedAxis::UInt32
@@ -52,6 +54,7 @@ mutable struct GizmoRenderer
         
         initial_constraints = AXIS_NONE
         move = false
+        first_move = true
         id_to_axis = (Vec3F(1,0,0), Vec3F(0,1,0), Vec3F(0,0,1))
         selected = UInt32(0)
         selectedAxis = UInt32(0)
@@ -67,7 +70,7 @@ mutable struct GizmoRenderer
         empty_vao = VertexArray()
         return new(
             corner_gizmo,move_gizmo,position,initial_plane_normal,initial_pos_diff,axes,
-            initial_constraints,move,id_to_axis,selected,selectedAxis,lastMousePosition,
+            initial_constraints,move,first_move,id_to_axis,selected,selectedAxis,lastMousePosition,
             ubo_axis,ubo_size,empty_vao
         )
     end
@@ -126,43 +129,63 @@ function _planeLineIntersection(eye::Vec3D, ray::Vec3D, plane_position::Vec3D, p
         return nothing
     end
 end
+function _moveAlongAxis(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Vec3D,Nothing}
+    axis_vector = AXIS_TO_VECTOR[gizmo.axes]
+    if (gizmo.first_move)
+        # ? Perpendicular to ray and the axis
+        perp = cross(ray, axis_vector)
+        # ? Plane normal is perpendicular to previous vector and the axis
+        gizmo.initial_plane_normal = cross(perp, axis_vector)
+    end
+    
+    angleDiff = dot(normalize(app._cam._at - app._cam._eye), normalize(gizmo.initial_plane_normal))
+    if (abs(angleDiff) >= MIN_VIEW_ANGLE_DIFF)
+        intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.initial_plane_normal))
+        if (intersection !== nothing)
+            # ? Projecting onto axis to get length
+            t = dot(intersection - gizmo.position, axis_vector)
+            return gizmo.position + t * axis_vector
+        end
+    end
+
+    return nothing
+end
+function _moveAlongPlane(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Vec3D,Nothing}
+    for axis in ALL_AXES
+        # ? Finds the perpendicular axis to the plane that'll be used as its normal
+        if (gizmo.axes & axis == 0)
+            angleDiff = dot(normalize(app._cam._at - app._cam._eye), normalize(AXIS_TO_VECTOR[axis]))
+            if (abs(angleDiff) >= MIN_VIEW_ANGLE_DIFF)
+                intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
+                if (intersection !== nothing)
+                    return intersection
+                end
+            end
+            break
+        end
+    end
+    
+    return nothing
+end
 
 function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     ray = get_ray(app, mouseX, mouseY)
     newPoint = nothing
     
     if (any(a -> a == gizmo.axes, ALL_AXES))
-        axis_vector = AXIS_TO_VECTOR[gizmo.axes]
-        if (!gizmo.move)
-            # ? Perpendicular to forward direction and the axis
-            perp = cross(ray, axis_vector)                          # perp = cross(gizmo.position - app._cam._eye, axis_vector)
-            # ? Plane normal is perpendicular to perp and the axis
-            gizmo.initial_plane_normal = cross(perp, axis_vector)
-        end
-        intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.initial_plane_normal))
-        if (intersection !== nothing)
-            # ? Projecting onto axis to get length
-            t = dot(intersection - gizmo.position, axis_vector)
-            newPoint = gizmo.position + t * axis_vector
-        end
+        newPoint = _moveAlongAxis(app, gizmo, ray)
     else
-        for axis in ALL_AXES
-            if (gizmo.axes & axis == 0)
-                intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
-                if (intersection !== nothing)
-                    newPoint = intersection
-                end
-                break
-            end
-        end
+        newPoint = _moveAlongPlane(app, gizmo, ray)
     end
 
-    # ? The first time the gizmo is moved
-    if (!gizmo.move && intersection !== nothing)
+    if (gizmo.first_move && newPoint !== nothing)
+        # ? Stores the initial difference between where the cursor points and where the gizmo is
         gizmo.initial_pos_diff = gizmo.position - newPoint
+        gizmo.first_move = false
     end
 
-    if (intersection !== nothing)
+    if (newPoint !== nothing)
+        # ? Applies the stored difference, so that the gizmo doesn't jump to the cursor at the beginning
         newPoint += gizmo.initial_pos_diff
         gizmo.position = newPoint
     end
@@ -182,8 +205,11 @@ function on_gizmo_left_click!(app)::Bool
     if 0 < app._hovered <= 3 # TODO: only when not moving yet
         axes_map = ALL_AXES
         gizmo.axes = axes_map[app._hovered]
-        _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
+
         gizmo.move = true
+        gizmo.first_move = true
+        _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
+
         app._scene_change = true
         return true
     end
@@ -243,9 +269,11 @@ function on_gizmo_drag_axis_start!(app, axis)::Bool
 
     gizmo.selectedAxis |= axis
     gizmo.axes = gizmo.selectedAxis
-    _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
-    
+
     gizmo.move = true
+    gizmo.first_move = true
+    _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
+
     app._scene_change = true
     return true
 end
@@ -257,6 +285,8 @@ function on_gizmo_drag_axis_end!(app, axis)::Bool
 
     gizmo.selectedAxis -= axis
     gizmo.axes = gizmo.selectedAxis
+    gizmo.first_move = true
+
     if (gizmo.selectedAxis == AXIS_NONE)
         gizmo.move = false
         gizmo.axes = gizmo.initial_constraints

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -18,7 +18,7 @@ mutable struct GizmoRenderer
     move_gizmo::Pipeline
     position::Vec3D
     initial_plane_normal::Vec3D
-    initial_pos_diff::Vec3D
+    initial_ray_diff::Vec3D
     axes::UInt32
     
     initial_constraints::UInt32
@@ -49,7 +49,7 @@ mutable struct GizmoRenderer
         )
         position = Vec3D(0.0)
         initial_plane_normal = Vec3D(0.0)
-        initial_pos_diff = Vec3D(0.0)
+        initial_ray_diff = Vec3F(0.0)
         axes = AXIS_NONE
         
         initial_constraints = AXIS_NONE
@@ -69,7 +69,7 @@ mutable struct GizmoRenderer
 
         empty_vao = VertexArray()
         return new(
-            corner_gizmo,move_gizmo,position,initial_plane_normal,initial_pos_diff,axes,
+            corner_gizmo,move_gizmo,position,initial_plane_normal,initial_ray_diff,axes,
             initial_constraints,move,first_move,id_to_axis,selected,selectedAxis,lastMousePosition,
             ubo_axis,ubo_size,empty_vao
         )
@@ -172,6 +172,15 @@ function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     ray = get_ray(app, mouseX, mouseY)
     newPoint = nothing
     
+    if (gizmo.first_move)
+        toPoint = normalize(gizmo.position - app._cam._eye)
+        # ? Stores the initial difference between where the eye-point vector and the eye-mouse ray
+        gizmo.initial_ray_diff = toPoint - ray
+    end
+
+    # ? Applies the stored difference, so that the gizmo doesn't jump to the cursor at the beginning
+    ray = Vec3F(ray + gizmo.initial_ray_diff)
+
     if (any(a -> a == gizmo.axes, ALL_AXES))
         newPoint = _moveAlongAxis(app, gizmo, ray)
     else
@@ -179,14 +188,10 @@ function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     end
 
     if (gizmo.first_move && newPoint !== nothing)
-        # ? Stores the initial difference between where the cursor points and where the gizmo is
-        gizmo.initial_pos_diff = gizmo.position - newPoint
         gizmo.first_move = false
     end
 
     if (newPoint !== nothing)
-        # ? Applies the stored difference, so that the gizmo doesn't jump to the cursor at the beginning
-        newPoint += gizmo.initial_pos_diff
         gizmo.position = newPoint
     end
 

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -16,6 +16,7 @@ mutable struct GizmoRenderer
     corner_gizmo::Pipeline
     move_gizmo::Pipeline
     position::Vec3D
+    initial_pos_diff::Vec3D
     axes::UInt32
     
     initial_constraints::UInt32
@@ -41,6 +42,7 @@ mutable struct GizmoRenderer
             frag = spv"renderers/gizmo/gizmo.frag"
         )
         position = Vec3D(0.0)
+        initial_pos_diff = Vec3D(0.0)
         axes = AXIS_NONE
         
         initial_constraints = AXIS_NONE
@@ -55,7 +57,7 @@ mutable struct GizmoRenderer
 
         empty_vao = VertexArray()
         return new(
-            corner_gizmo,move_gizmo,position,axes,
+            corner_gizmo,move_gizmo,position,initial_pos_diff,axes,
             initial_constraints,move,id_to_axis,selected,selectedAxis,lastMousePosition,
             ubo,empty_vao
         )
@@ -144,6 +146,12 @@ function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
         end
     end
 
+    # ? The first time the gizmo is moved
+    if (!gizmo.move)
+        gizmo.initial_pos_diff = gizmo.position - newPoint
+    end
+    newPoint += gizmo.initial_pos_diff
+
     gizmo.position = newPoint
     if gizmo.selected > 3
         p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
@@ -160,8 +168,8 @@ function on_gizmo_left_click!(app)::Bool
     if 0 < app._hovered <= 3 # TODO: only when not moving yet
         axes_map = ALL_AXES
         gizmo.axes = axes_map[app._hovered]
-        gizmo.move = true
         _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
+        gizmo.move = true
         app._scene_change = true
         return true
     end
@@ -221,9 +229,9 @@ function on_gizmo_drag_axis_start!(app, axis)::Bool
 
     gizmo.selectedAxis |= axis
     gizmo.axes = gizmo.selectedAxis
-    gizmo.move = true
     _move_gizmo!(app, gizmo, gizmo.lastMousePosition[1], gizmo.lastMousePosition[2])
     
+    gizmo.move = true
     app._scene_change = true
     return true
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -15,6 +15,7 @@ mutable struct GizmoRenderer
     move::Bool
     id_to_axis::Tuple{Vec3F,Vec3F,Vec3F}
     selected::UInt32
+    selectedAxis::UInt32
 
     ubo::MappedBuffer{Vec4F}
     empty_vao::VertexArray
@@ -38,6 +39,7 @@ mutable struct GizmoRenderer
         move = false
         id_to_axis = (Vec3F(1,0,0), Vec3F(0,1,0), Vec3F(0,0,1))
         selected = UInt32(0)
+        selectedAxis = UInt32(0)
 
         ubo = MappedBuffer{Vec4F}()
         reserve!(ubo, 1, 0)
@@ -45,7 +47,7 @@ mutable struct GizmoRenderer
         empty_vao = VertexArray()
         return new(
             corner_gizmo,move_gizmo,position,axes,
-            initial_constraints,move,id_to_axis,selected,
+            initial_constraints,move,id_to_axis,selected,selectedAxis,
             ubo,empty_vao
         )
     end
@@ -175,5 +177,26 @@ function on_gizmo_drag!(app, event)::Bool
         end
     end
 
+    return true
+end
+
+function on_gizmo_drag_axis_start!(app, axis)::Bool
+    gizmo = app._opengl._renderers.gizmo
+    if (gizmo.selectedAxis & axis > 0 || gizmo.selectedAxis | axis == AXIS_FULL)
+        return false
+    end
+
+    gizmo.selectedAxis |= axis
+    println(gizmo.selectedAxis)
+    return true
+end
+function on_gizmo_drag_axis_end!(app, axis)::Bool
+    gizmo = app._opengl._renderers.gizmo
+    if (gizmo.selectedAxis & axis == 0)
+        return false
+    end
+
+    gizmo.selectedAxis -= axis
+    println(gizmo.selectedAxis)
     return true
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -92,7 +92,7 @@ function draw_ui(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
     return nothing
 end
 
-function _seg2segSqDistParams(p::Vec3D, v::Vec3D, q::Vec3D, w::Vec3D) :: Tuple{Float64,Float64,Float64}
+function _seg2segSqDistParams(p::Vec3D,v::Vec3D,q::Vec3D,w::Vec3D)::Tuple{Float64,Float64,Float64}
     r  = q - p
 
     # v2, w2 : magnitudes^2
@@ -110,9 +110,17 @@ function _seg2segSqDistParams(p::Vec3D, v::Vec3D, q::Vec3D, w::Vec3D) :: Tuple{F
     return (d2, t, s)
 end
 
+function _closestPointOnAxis(eye::Vec3D, ray::Vec3D, position::Vec3D, axis_vector::Vec3D)::Vec3D
+    (_, _, s) = _seg2segSqDistParams(eye, ray, position, axis_vector)
+    return Vec3D(position + axis_vector * s)
+end
+function _planeLineIntersection()
+    # plane intersection
+end
+
 function on_gizmo_left_click!(app)::Bool
     gizmo = app._opengl._renderers.gizmo
-    if 0 < app._hovered <= 3
+    if 0 < app._hovered <= 3 # TODO: only when not moving yet
         axes_map = UInt32[AXIS_X, AXIS_Y, AXIS_Z]
         gizmo.axes = axes_map[app._hovered]
         gizmo.move = true
@@ -158,16 +166,23 @@ end
 
 function on_gizmo_drag!(app, event)::Bool
     gizmo = app._opengl._renderers.gizmo
-    if !gizmo.move || gizmo.axes == AXIS_NONE
+    if !gizmo.move || (gizmo.axes == AXIS_NONE && gizmo.selectedAxis == AXIS_NONE)
         return false
     end
 
-    selected_axis_idx = gizmo.axes == AXIS_Y ? 2 : (gizmo.axes == AXIS_Z ? 3 : 1)
-
     ray = get_ray(app, event.x, event.y)
-    (_, _, s) = _seg2segSqDistParams(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.id_to_axis[selected_axis_idx]))
+    
+    newPoint = Vec3D(0,0,0)
+    if (gizmo.axes != AXIS_NONE)
+        selected_axis_idx = gizmo.axes == AXIS_Y ? 2 : (gizmo.axes == AXIS_Z ? 3 : 1)
+        axis_vector = gizmo.id_to_axis[selected_axis_idx]
+        newPoint = _closestPointOnAxis(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(axis_vector))
+    else
+        # _planeLineIntersection()
+        # TODO: plane intersection
+    end
 
-    gizmo.position = Vec3D(gizmo.position + gizmo.id_to_axis[selected_axis_idx] * s)
+    gizmo.position = newPoint
     if gizmo.selected > 3
         p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
         if p._coord != gizmo.position
@@ -187,7 +202,11 @@ function on_gizmo_drag_axis_start!(app, axis)::Bool
     end
 
     gizmo.selectedAxis |= axis
-    println(gizmo.selectedAxis)
+    gizmo.axes = gizmo.selectedAxis
+    gizmo.move = true
+    
+    app._scene_change = true
+    # println(gizmo.selectedAxis)
     return true
 end
 function on_gizmo_drag_axis_end!(app, axis)::Bool
@@ -197,6 +216,13 @@ function on_gizmo_drag_axis_end!(app, axis)::Bool
     end
 
     gizmo.selectedAxis -= axis
-    println(gizmo.selectedAxis)
+    gizmo.axes = gizmo.selectedAxis
+    if (gizmo.selectedAxis == AXIS_NONE)
+        gizmo.move = false
+        gizmo.axes = gizmo.initial_constraints
+    end
+
+    app._scene_change = true
+    # println(gizmo.selectedAxis)
     return true
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -5,6 +5,12 @@ const AXIS_Z::UInt32    = UInt32(0x4)
 const AXIS_FULL::UInt32 = UInt32(0x7)
 export AXIS_NONE, AXIS_X, AXIS_Y, AXIS_Z, AXIS_FULL
 
+const AXIS_TO_VECTOR = Dict{UInt32,Vec3F}(
+    AXIS_X => Vec3F(1,0,0),
+    AXIS_Y => Vec3F(0,1,0),
+    AXIS_Z => Vec3F(0,0,1),
+)
+
 mutable struct GizmoRenderer
     corner_gizmo::Pipeline
     move_gizmo::Pipeline
@@ -114,8 +120,10 @@ function _closestPointOnAxis(eye::Vec3D, ray::Vec3D, position::Vec3D, axis_vecto
     (_, _, s) = _seg2segSqDistParams(eye, ray, position, axis_vector)
     return Vec3D(position + axis_vector * s)
 end
-function _planeLineIntersection()
-    # plane intersection
+function _planeLineIntersection(eye::Vec3D, ray::Vec3D, position::Vec3D, normal_vector::Vec3D)
+    line = PLine(eye, ray)
+    plane = PPlane(position, normal_vector)
+    return PrimitiveToPrimitiveIntersection(line, plane)
 end
 
 function on_gizmo_left_click!(app)::Bool
@@ -173,13 +181,19 @@ function on_gizmo_drag!(app, event)::Bool
     ray = get_ray(app, event.x, event.y)
     
     newPoint = Vec3D(0,0,0)
-    if (gizmo.axes != AXIS_NONE)
-        selected_axis_idx = gizmo.axes == AXIS_Y ? 2 : (gizmo.axes == AXIS_Z ? 3 : 1)
-        axis_vector = gizmo.id_to_axis[selected_axis_idx]
+    if (gizmo.axes == AXIS_X || gizmo.axes == AXIS_Y || gizmo.axes == AXIS_Z)
+        axis_vector = AXIS_TO_VECTOR[gizmo.axes]
         newPoint = _closestPointOnAxis(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(axis_vector))
     else
-        # _planeLineIntersection()
-        # TODO: plane intersection
+        normal_vector = Vec3F(0,0,0)
+        for axis in [AXIS_X, AXIS_Y, AXIS_Z]
+            if (gizmo.axes & axis == 0)
+                normal_vector = AXIS_TO_VECTOR[axis]
+                break
+            end
+        end
+        newPoint = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(normal_vector))
+        println(newPoint)
     end
 
     gizmo.position = newPoint
@@ -206,7 +220,6 @@ function on_gizmo_drag_axis_start!(app, axis)::Bool
     gizmo.move = true
     
     app._scene_change = true
-    # println(gizmo.selectedAxis)
     return true
 end
 function on_gizmo_drag_axis_end!(app, axis)::Bool
@@ -223,6 +236,5 @@ function on_gizmo_drag_axis_end!(app, axis)::Bool
     end
 
     app._scene_change = true
-    # println(gizmo.selectedAxis)
     return true
 end

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -24,7 +24,6 @@ mutable struct GizmoRenderer
     initial_constraints::UInt32
     move::Bool
     first_move::Bool
-    id_to_axis::Tuple{Vec3F,Vec3F,Vec3F}
     selected::UInt32
     selectedAxis::UInt32
     lastMousePosition::Tuple{Float64,Float64}
@@ -55,7 +54,6 @@ mutable struct GizmoRenderer
         initial_constraints = AXIS_NONE
         move = false
         first_move = true
-        id_to_axis = (Vec3F(1,0,0), Vec3F(0,1,0), Vec3F(0,0,1))
         selected = UInt32(0)
         selectedAxis = UInt32(0)
         lastMousePosition = (Float64(0), Float64(0))
@@ -70,7 +68,7 @@ mutable struct GizmoRenderer
         empty_vao = VertexArray()
         return new(
             corner_gizmo,move_gizmo,position,initial_plane_normal,initial_ray_diff,axes,
-            initial_constraints,move,first_move,id_to_axis,selected,selectedAxis,lastMousePosition,
+            initial_constraints,move,first_move,selected,selectedAxis,lastMousePosition,
             ubo_axis,ubo_size,empty_vao
         )
     end
@@ -268,7 +266,7 @@ end
 
 function on_gizmo_drag_axis_start!(app, axis)::Bool
     gizmo = app._opengl._renderers.gizmo
-    if (gizmo.selectedAxis & axis > 0 || gizmo.selectedAxis | axis == AXIS_FULL)
+    if (gizmo.axes == 0 || gizmo.selectedAxis & axis > 0 || gizmo.selectedAxis | axis == AXIS_FULL)
         return false
     end
 

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -59,6 +59,8 @@ mutable struct GizmoRenderer
         reserve!(ubo_axis, 1, 0)
         ubo_size = MappedBuffer{Float32}()
         reserve!(ubo_size, 2, 0)
+        ubo_size[1] = 1.0
+        ubo_size[2] = 1.0
 
         empty_vao = VertexArray()
         return new(
@@ -91,8 +93,6 @@ function pre_draw(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
         Float32(renderer.position[3]),
         reinterpret(Float32, renderer.axes)
     )
-    renderer.ubo_size[1] = Float32(0.5)
-    renderer.ubo_size[2] = Float32(2.0)
     return nothing
 end
 

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -16,6 +16,7 @@ mutable struct GizmoRenderer
     corner_gizmo::Pipeline
     move_gizmo::Pipeline
     position::Vec3D
+    initial_plane_normal::Vec3D
     initial_pos_diff::Vec3D
     axes::UInt32
     
@@ -45,6 +46,7 @@ mutable struct GizmoRenderer
             frag = spv"renderers/gizmo/gizmo.frag"
         )
         position = Vec3D(0.0)
+        initial_plane_normal = Vec3D(0.0)
         initial_pos_diff = Vec3D(0.0)
         axes = AXIS_NONE
         
@@ -64,7 +66,7 @@ mutable struct GizmoRenderer
 
         empty_vao = VertexArray()
         return new(
-            corner_gizmo,move_gizmo,position,initial_pos_diff,axes,
+            corner_gizmo,move_gizmo,position,initial_plane_normal,initial_pos_diff,axes,
             initial_constraints,move,id_to_axis,selected,selectedAxis,lastMousePosition,
             ubo_axis,ubo_size,empty_vao
         )
@@ -113,56 +115,58 @@ function draw_ui(renderer::GizmoRenderer,cam::Camera,window::GLFWData)::Nothing
     return nothing
 end
 
-function _seg2segSqDistParams(p::Vec3D,v::Vec3D,q::Vec3D,w::Vec3D)::Tuple{Float64,Float64,Float64}
-    r  = q - p
+function _planeLineIntersection(eye::Vec3D, ray::Vec3D, plane_position::Vec3D, plane_normal::Vec3D)::Union{Vec3D,Nothing}
+    cosRayNormal = dot(ray, plane_normal)
+    if (cosRayNormal == 0.0) return nothing end
 
-    # v2, w2 : magnitudes^2
-    # vw : parallellity
-    v2 = dot(v,v); w2 = dot(w,w); vw = dot(v,w)
-
-	D  = v2*w2 - vw*vw # ‖v×w‖²
-    a1 = dot(v,r); a2 = dot(w,r); a3 = dot(cross(v,w), r)
-	
-    t  = ( w2*a1 - vw*a2 ) / D
-    s  = ( vw*a1 - v2*a2 ) / D
-	
-    d2 = a3*a3 / D
-	
-    return (d2, t, s)
-end
-function _closestPointOnAxis(eye::Vec3D, ray::Vec3D, position::Vec3D, axis_vector::Vec3D)::Vec3D
-    (_, _, s) = _seg2segSqDistParams(eye, ray, position, axis_vector)
-    return Vec3D(position + axis_vector * s)
-end
-function _planeLineIntersection(eye::Vec3D, ray::Vec3D, position::Vec3D, normal_vector::Vec3D)
-    line = PLine(eye, ray)
-    plane = PPlane(position, normal_vector)
-    return PrimitiveToPrimitiveIntersection(line, plane)
+    t = dot(plane_position - eye, plane_normal) / cosRayNormal
+    if (t >= 0)
+        return eye + t * ray
+    else
+        return nothing
+    end
 end
 
 function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     ray = get_ray(app, mouseX, mouseY)
-    newPoint = Vec3D(0)
+    newPoint = nothing
     
     if (any(a -> a == gizmo.axes, ALL_AXES))
         axis_vector = AXIS_TO_VECTOR[gizmo.axes]
-        newPoint = _closestPointOnAxis(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(axis_vector))
+        if (!gizmo.move)
+            # ? Perpendicular to forward direction and the axis
+            perp = cross(ray, axis_vector)                          # perp = cross(gizmo.position - app._cam._eye, axis_vector)
+            # ? Plane normal is perpendicular to perp and the axis
+            gizmo.initial_plane_normal = cross(perp, axis_vector)
+        end
+        intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.initial_plane_normal))
+        if (intersection !== nothing)
+            # ? Projecting onto axis to get length
+            t = dot(intersection - gizmo.position, axis_vector)
+            newPoint = gizmo.position + t * axis_vector
+        end
     else
         for axis in ALL_AXES
             if (gizmo.axes & axis == 0)
-                newPoint = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
+                intersection = _planeLineIntersection(Vec3D(app._cam._eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
+                if (intersection !== nothing)
+                    newPoint = intersection
+                end
                 break
             end
         end
     end
 
     # ? The first time the gizmo is moved
-    if (!gizmo.move)
+    if (!gizmo.move && intersection !== nothing)
         gizmo.initial_pos_diff = gizmo.position - newPoint
     end
-    newPoint += gizmo.initial_pos_diff
 
-    gizmo.position = newPoint
+    if (intersection !== nothing)
+        newPoint += gizmo.initial_pos_diff
+        gizmo.position = newPoint
+    end
+
     if gizmo.selected > 3
         p::PointDependent = getDependentNode(getModel(app), gizmo.selected - ID_LOWER_BOUND)::PointDependent
         if p._coord != gizmo.position

--- a/src/Widgets/Windows/options_window.jl
+++ b/src/Widgets/Windows/options_window.jl
@@ -5,32 +5,48 @@ mutable struct OptionsWindow <: WindowDNA
     _whitebg::Ref{Bool}
     _bgColor::Array{Cfloat}
 
+    _gizmoLength::Ref{Float32}
+    _gizmoThickness::Ref{Float32}
+
     function OptionsWindow(color)
-        new(Window(), false, Cfloat[color[1], color[2], color[3]])
+        whitebg = false
+        bgColor = Cfloat[color[1], color[2], color[3]]
+        gizmoLength = 1.0
+        gizmoThickness = 1.0
+        new(Window(), whitebg, bgColor, gizmoLength, gizmoThickness)
     end
 end
 
 _Window_(self::OptionsWindow)::Window = self._window
 getWindowName(self::OptionsWindow) = "Options"
 
-function setBackground(self::OptionsWindow, app::AppDNA)
+function _updateScene!(app::AppDNA)
+    update!(getOpenGL(app), app._cam, true, UInt32(0))
+end
+function _setBackground(self::OptionsWindow, app::AppDNA)
     if (self._whitebg[])
         glClearColor(1.0f0, 1.0f0, 1.0f0, 1.0f0)
     else
         glClearColor(self._bgColor[1], self._bgColor[2], self._bgColor[3], 1.0f0)
     end
-    # updates so that the background changes instantly, instead of waiting for an actual scene_change
-    update!(getOpenGL(app), app._cam, true, UInt32(0))
+    # ? updates so that the background changes instantly, instead of waiting for an actual scene_change
+    _updateScene!(app)
+end
+function _setGizmo(self::OptionsWindow, app::AppDNA)
+    gizmo = app._opengl._renderers.gizmo
+    gizmo.ubo_size[1] = self._gizmoLength[]
+    gizmo.ubo_size[2] = self._gizmoThickness[]
+    _updateScene!(app)
 end
 
 function renderContent(self::OptionsWindow, app::AppDNA)
     if (CImGui.Checkbox("White background", self._whitebg))
-        setBackground(self, app)
+        _setBackground(self, app)
     end
 
     CImGui.BeginDisabled(self._whitebg[])
     if (CImGui.ColorEdit3("Custom background color", self._bgColor, CImGui.ImGuiColorEditFlags_NoInputs))
-        setBackground(self, app)
+        _setBackground(self, app)
     end
     CImGui.EndDisabled()
     
@@ -38,6 +54,15 @@ function renderContent(self::OptionsWindow, app::AppDNA)
     if (CImGui.Button("Default"))
         defcol = getOpenGL(app)._backgroundCol
         self._bgColor = Cfloat[defcol[1], defcol[2], defcol[3]]
-        setBackground(self, app)
+        _setBackground(self, app)
+    end
+
+    if (CImGui.CollapsingHeader("Gizmo settings"))
+        if (CImGui.SliderFloat("Length", self._gizmoLength, 0.5, 2.0))
+            _setGizmo(self, app)
+        end
+        if (CImGui.SliderFloat("Thickness", self._gizmoThickness, 0.5, 2.0))
+            _setGizmo(self, app)
+        end
     end
 end

--- a/src/Widgets/coordinates_widget.jl
+++ b/src/Widgets/coordinates_widget.jl
@@ -1,0 +1,64 @@
+
+mutable struct CoordinatesWidget <: ImGuiWidgetDNA
+    _widget::ImGuiWidget
+    _coordinates::Vec3D
+
+    _posX::Int
+    _posY::Int
+    
+    _width::Int
+    _height::Int
+
+    _padding::Int
+
+    function CoordinatesWidget()
+        new(ImGuiWidget(),Vec3D(0),0,0,0,0,0)
+    end
+end
+
+_ImGuiWidget_(self::CoordinatesWidget)::ImGuiWidget = return self._widget
+
+function render(self::CoordinatesWidget, app::AppDNA)
+    imgui = getImGui(app)
+
+    CImGui.SetNextWindowPos((self._posX,self._posY))
+    CImGui.SetNextWindowSize((self._width,self._height))
+
+    CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowRounding,5.0)
+    CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowPadding,(self._padding,self._padding))
+
+    CImGui.Begin("CoordinatesWidget",C_NULL,
+        CImGui.ImGuiWindowFlags_NoSavedSettings | 
+        CImGui.ImGuiWindowFlags_NoResize | CImGui.ImGuiWindowFlags_NoMove |
+        CImGui.ImGuiWindowFlags_NoTitleBar | CImGui.ImGuiWindowFlags_NoCollapse |
+        CImGui.ImGuiWindowFlags_NoDecoration)
+
+    coords = "(" * string(round(self._coordinates[1]; digits = 1)) * ", " * string(round(self._coordinates[2]; digits = 1)) * ", " * string(round(self._coordinates[3]; digits = 1)) * ")"
+    CImGui.Text(coords)
+    
+    CImGui.End()
+    CImGui.PopStyleVar(2)
+end
+
+function resize!(self::CoordinatesWidget,x::Int,y::Int)
+    self._posX = 10
+    self._posY = y - 40
+
+    plusDigits = 0
+    
+    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[1]))))
+    if (self._coordinates[1] < 0) plusDigits += 1 end
+
+    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[2]))))
+    if (self._coordinates[2] < 0) plusDigits += 1 end
+
+    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[3]))))
+    if (self._coordinates[3] < 0) plusDigits += 1 end
+
+    println(plusDigits)
+
+    self._width = 100 + plusDigits * 6
+    self._height = 20
+
+    self._padding = 8
+end

--- a/src/Widgets/coordinates_widget.jl
+++ b/src/Widgets/coordinates_widget.jl
@@ -1,7 +1,7 @@
 
 mutable struct CoordinatesWidget <: ImGuiWidgetDNA
     _widget::ImGuiWidget
-    _coordinates::Vec3D
+    _gizmo::GizmoRenderer
 
     _posX::Int
     _posY::Int
@@ -11,8 +11,8 @@ mutable struct CoordinatesWidget <: ImGuiWidgetDNA
 
     _padding::Int
 
-    function CoordinatesWidget()
-        new(ImGuiWidget(),Vec3D(0),0,0,0,0,0)
+    function CoordinatesWidget(gizmo::GizmoRenderer)
+        new(ImGuiWidget(),gizmo,0,0,0,0,0)
     end
 end
 
@@ -21,23 +21,25 @@ _ImGuiWidget_(self::CoordinatesWidget)::ImGuiWidget = return self._widget
 function render(self::CoordinatesWidget, app::AppDNA)
     imgui = getImGui(app)
 
-    CImGui.SetNextWindowPos((self._posX,self._posY))
-    CImGui.SetNextWindowSize((self._width,self._height))
+    if (self._gizmo.axes > 0)
+        CImGui.SetNextWindowPos((self._posX,self._posY))
+        CImGui.SetNextWindowSize((self._width,self._height))
 
-    CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowRounding,5.0)
-    CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowPadding,(self._padding,self._padding))
+        CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowRounding,5.0)
+        CImGui.PushStyleVar(CImGui.ImGuiStyleVar_WindowPadding,(self._padding,self._padding))
 
-    CImGui.Begin("CoordinatesWidget",C_NULL,
-        CImGui.ImGuiWindowFlags_NoSavedSettings | 
-        CImGui.ImGuiWindowFlags_NoResize | CImGui.ImGuiWindowFlags_NoMove |
-        CImGui.ImGuiWindowFlags_NoTitleBar | CImGui.ImGuiWindowFlags_NoCollapse |
-        CImGui.ImGuiWindowFlags_NoDecoration)
+        CImGui.Begin("CoordinatesWidget",C_NULL,
+            CImGui.ImGuiWindowFlags_NoSavedSettings | 
+            CImGui.ImGuiWindowFlags_NoResize | CImGui.ImGuiWindowFlags_NoMove |
+            CImGui.ImGuiWindowFlags_NoTitleBar | CImGui.ImGuiWindowFlags_NoCollapse |
+            CImGui.ImGuiWindowFlags_NoDecoration)
 
-    coords = "(" * string(round(self._coordinates[1]; digits = 1)) * ", " * string(round(self._coordinates[2]; digits = 1)) * ", " * string(round(self._coordinates[3]; digits = 1)) * ")"
-    CImGui.Text(coords)
-    
-    CImGui.End()
-    CImGui.PopStyleVar(2)
+        coords = "(" * string(round(self._gizmo.position[1]; digits = 1)) * ", " * string(round(self._gizmo.position[2]; digits = 1)) * ", " * string(round(self._gizmo.position[3]; digits = 1)) * ")"
+        CImGui.Text(coords)
+        
+        CImGui.End()
+        CImGui.PopStyleVar(2)
+    end
 end
 
 function resize!(self::CoordinatesWidget,x::Int,y::Int)
@@ -45,17 +47,12 @@ function resize!(self::CoordinatesWidget,x::Int,y::Int)
     self._posY = y - 40
 
     plusDigits = 0
-    
-    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[1]))))
-    if (self._coordinates[1] < 0) plusDigits += 1 end
-
-    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[2]))))
-    if (self._coordinates[2] < 0) plusDigits += 1 end
-
-    plusDigits += floor(Int, log10(max(1.0, abs(self._coordinates[3]))))
-    if (self._coordinates[3] < 0) plusDigits += 1 end
-
-    println(plusDigits)
+    plusDigits += floor(Int, log10(max(1.0, abs(self._gizmo.position[1]))))
+    if (self._gizmo.position[1] < 0) plusDigits += 1 end
+    plusDigits += floor(Int, log10(max(1.0, abs(self._gizmo.position[2]))))
+    if (self._gizmo.position[2] < 0) plusDigits += 1 end
+    plusDigits += floor(Int, log10(max(1.0, abs(self._gizmo.position[3]))))
+    if (self._gizmo.position[3] < 0) plusDigits += 1 end
 
     self._width = 100 + plusDigits * 6
     self._height = 20

--- a/src/Widgets/points_window.jl
+++ b/src/Widgets/points_window.jl
@@ -64,7 +64,7 @@ end
 
 const _POINT_STYLE_VALUES = [POINT_NONE, POINT_PLUS]
 const _POINT_STYLE_LABELS = [".", "+"]
-function renderContent(self::PointsWindow)
+function renderContent(self::PointsWindow, app::AppDNA)
     col_flags = CImGui.ImGuiTableColumnFlags_WidthFixed
     
     if !CImGui.BeginTable("points_tbl", 8,
@@ -106,6 +106,8 @@ function renderContent(self::PointsWindow)
             y_ref = Ref(Cdouble(coord.y))
             z_ref = Ref(Cdouble(coord.z))
 
+            position_changed = false
+
             CImGui.TableNextColumn()
             CImGui.PushItemWidth(-1)
             if CImGui.InputDouble("##x$id", x_ref, 0.0, 0.0, "%.4f")
@@ -115,6 +117,7 @@ function renderContent(self::PointsWindow)
                     coord[3]
                 )
                 schedule(self._model,node)
+                position_changed = true
             end
 
             CImGui.TableNextColumn()
@@ -126,6 +129,7 @@ function renderContent(self::PointsWindow)
                     coord[3]
                 )
                 schedule(self._model,node)
+                position_changed = true
             end
 
             CImGui.TableNextColumn()
@@ -137,6 +141,11 @@ function renderContent(self::PointsWindow)
                     z_ref[]
                 )
                 schedule(self._model,node)
+                position_changed = true
+            end
+
+            if (position_changed)
+                update_position!(app, node)
             end
         else
             CImGui.TableNextColumn()

--- a/src/app.jl
+++ b/src/app.jl
@@ -98,14 +98,9 @@ function setup_callbacks(self::App)::Nothing
     register_callback!(event -> on_gizmo_right_click!(self), self._inputs, MOUSE_BUTTON_DOWN, Cint(GLFW.MOUSE_BUTTON_RIGHT))
     register_callback!(event -> on_gizmo_left_release!(self), self._inputs, MOUSE_BUTTON_UP,   Cint(GLFW.MOUSE_BUTTON_LEFT))
     register_callback!(event -> begin
-        if (on_gizmo_drag!(self, event))
-            gizmo = self._opengl._renderers.gizmo
-            self._imgui._coordinatesWidget._coordinates = gizmo.position
-            resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
-            return true
-        else
-            return false
-        end
+        drag = on_gizmo_drag!(self, event)
+        resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
+        return drag
     end, self._inputs, MOUSE_MOVE)
     
     # --- KEYBOARD DOWN EVENTS ---

--- a/src/app.jl
+++ b/src/app.jl
@@ -98,6 +98,16 @@ function setup_callbacks(self::App)::Nothing
     register_callback!(event -> on_gizmo_right_click!(self), self._inputs, MOUSE_BUTTON_DOWN, Cint(GLFW.MOUSE_BUTTON_RIGHT))
     register_callback!(event -> on_gizmo_left_release!(self), self._inputs, MOUSE_BUTTON_UP,   Cint(GLFW.MOUSE_BUTTON_LEFT))
     register_callback!(event -> on_gizmo_drag!(self, event), self._inputs, MOUSE_MOVE)
+    
+    # --- KEYBOARD DOWN EVENTS ---
+    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_X), self._inputs, KEY_DOWN, Cint(GLFW.KEY_X))
+    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_Y), self._inputs, KEY_DOWN, Cint(GLFW.KEY_Y))
+    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_Z), self._inputs, KEY_DOWN, Cint(GLFW.KEY_Z))
+    
+    # --- KEYBOARD UP EVENTS ---
+    register_callback!(event -> on_gizmo_drag_axis_end!(self, AXIS_X), self._inputs, KEY_UP, Cint(GLFW.KEY_X))
+    register_callback!(event -> on_gizmo_drag_axis_end!(self, AXIS_Y), self._inputs, KEY_UP, Cint(GLFW.KEY_Y))
+    register_callback!(event -> on_gizmo_drag_axis_end!(self, AXIS_Z), self._inputs, KEY_UP, Cint(GLFW.KEY_Z))
 
     register_callbacks!(self._inputs, self._manipulator)
     return nothing

--- a/src/app.jl
+++ b/src/app.jl
@@ -97,7 +97,16 @@ function setup_callbacks(self::App)::Nothing
     register_callback!(event -> on_gizmo_left_click!(self), self._inputs, MOUSE_BUTTON_DOWN, Cint(GLFW.MOUSE_BUTTON_LEFT))
     register_callback!(event -> on_gizmo_right_click!(self), self._inputs, MOUSE_BUTTON_DOWN, Cint(GLFW.MOUSE_BUTTON_RIGHT))
     register_callback!(event -> on_gizmo_left_release!(self), self._inputs, MOUSE_BUTTON_UP,   Cint(GLFW.MOUSE_BUTTON_LEFT))
-    register_callback!(event -> on_gizmo_drag!(self, event), self._inputs, MOUSE_MOVE)
+    register_callback!(event -> begin
+        if (on_gizmo_drag!(self, event))
+            gizmo = self._opengl._renderers.gizmo
+            self._imgui._coordinatesWidget._coordinates = gizmo.position
+            resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
+            return true
+        else
+            return false
+        end
+    end, self._inputs, MOUSE_MOVE)
     
     # --- KEYBOARD DOWN EVENTS ---
     register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_X), self._inputs, KEY_DOWN, Cint(GLFW.KEY_X))

--- a/src/app.jl
+++ b/src/app.jl
@@ -104,9 +104,21 @@ function setup_callbacks(self::App)::Nothing
     end, self._inputs, MOUSE_MOVE)
     
     # --- KEYBOARD DOWN EVENTS ---
-    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_X), self._inputs, KEY_DOWN, Cint(GLFW.KEY_X))
-    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_Y), self._inputs, KEY_DOWN, Cint(GLFW.KEY_Y))
-    register_callback!(event -> on_gizmo_drag_axis_start!(self, AXIS_Z), self._inputs, KEY_DOWN, Cint(GLFW.KEY_Z))
+    register_callback!(event -> begin
+        drag = on_gizmo_drag_axis_start!(self, AXIS_X)
+        resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
+        return drag
+    end, self._inputs, KEY_DOWN, Cint(GLFW.KEY_X))
+    register_callback!(event -> begin
+        drag = on_gizmo_drag_axis_start!(self, AXIS_Y)
+        resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
+        return drag
+    end, self._inputs, KEY_DOWN, Cint(GLFW.KEY_Y))
+    register_callback!(event -> begin
+        drag = on_gizmo_drag_axis_start!(self, AXIS_Z)
+        resize!(self._imgui._coordinatesWidget, Int(self._glfw.width), Int(self._glfw.height))
+        return drag
+    end, self._inputs, KEY_DOWN, Cint(GLFW.KEY_Z))
     
     # --- KEYBOARD UP EVENTS ---
     register_callback!(event -> on_gizmo_drag_axis_end!(self, AXIS_X), self._inputs, KEY_UP, Cint(GLFW.KEY_X))

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -40,16 +40,16 @@ end
 function get_ray(app::AppDNA, x, y)::Vec3F
     self = app._cam
     mouse = Vec2F(((x + 0.5) / app._glfw.width) * 2.0 - 1.0, ((y + 0.5) / app._glfw.height) * 2.0 - 1.0)
-    
-    forward = normalize(self._at - self._eye)
-    right = normalize(cross(forward, self._up))
-    camUp = cross(right, forward)
+
+    forward = -Vec3F(self._view[3,1],self._view[3,2],self._view[3,3])
+    right = Vec3F(self._view[1,1],self._view[1,2],self._view[1,3])
+    camUp = Vec3F(self._view[2,1],self._view[2,2],self._view[2,3])
 
     halfHeight = tan(deg2rad(self._fov) / 2.0) * self._zNear
     halfWidth = halfHeight * self._aspect
 
     nearPlaneCenter = self._eye + forward * self._zNear
-    nearPlaneMouse = nearPlaneCenter - right * (mouse[1] * halfWidth) + camUp * (mouse[2] * halfHeight)
+    nearPlaneMouse = nearPlaneCenter + right * (mouse[1] * halfWidth) + camUp * (mouse[2] * halfHeight)
     ray = normalize(nearPlaneMouse - self._eye)
 
     return ray

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -39,7 +39,7 @@ function get_matrices(self::Camera)
 end
 function get_ray(app::AppDNA, x, y)::Vec3F
     self = app._cam
-    mouse = Vec2F((x / app._glfw.width) * 2.0 - 1.0, (y / app._glfw.height) * 2.0 - 1.0)
+    mouse = Vec2F(((x + 0.5) / app._glfw.width) * 2.0 - 1.0, ((y + 0.5) / app._glfw.height) * 2.0 - 1.0)
     
     forward = normalize(self._at - self._eye)
     right = normalize(cross(forward, self._up))

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -37,6 +37,23 @@ end
 function get_matrices(self::Camera)
     return self._view_proj, self._view, self._proj
 end
+function get_ray(app::AppDNA, x, y)::Vec3F
+    self = app._cam
+    mouse = Vec2F((x / app._glfw.width) * 2.0 - 1.0, (y / app._glfw.height) * 2.0 - 1.0)
+    
+    forward = normalize(self._at - self._eye)
+    right = normalize(cross(forward, self._up))
+    camUp = cross(right, forward)
+
+    halfHeight = tan(deg2rad(self._fov) / 2.0) * self._zNear
+    halfWidth = halfHeight * self._aspect
+
+    nearPlaneCenter = self._eye + forward * self._zNear
+    nearPlaneMouse = nearPlaneCenter - right * (mouse[1] * halfWidth) + camUp * (mouse[2] * halfHeight)
+    ray = normalize(nearPlaneMouse - self._eye)
+
+    return ray
+end
 
 function set_view!(self::Camera,eye::Vec3F,at::Vec3F,up::Vec3F)
     self._eye = eye

--- a/src/imgui_data.jl
+++ b/src/imgui_data.jl
@@ -21,6 +21,8 @@ mutable struct ImGuiData <: ImGuiDNA
     _widgets::Vector{ImGuiWidgetDNA}
     _dock::Dock
 
+    _coordinatesWidget::CoordinatesWidget
+
     # GREEN Thread
     function ImGuiData(app::AppDNA)
         glfwD::GLFWData = getGLFW(app)
@@ -62,8 +64,10 @@ mutable struct ImGuiData <: ImGuiDNA
         push!(widgets,dock)
         push!(widgets,ResetWidget())
         push!(widgets,OptionsWidget(openglD._backgroundCol))
+        coordinatesWidget = CoordinatesWidget()
+        push!(widgets,coordinatesWidget)
         
-        self = new(textFont,iconFont,pool,dependents,widgets,dock)
+        self = new(textFont,iconFont,pool,dependents,widgets,dock,coordinatesWidget)
         
         resetObservers!(self)
         resize!(self,glfwD)

--- a/src/imgui_data.jl
+++ b/src/imgui_data.jl
@@ -64,7 +64,7 @@ mutable struct ImGuiData <: ImGuiDNA
         push!(widgets,dock)
         push!(widgets,ResetWidget())
         push!(widgets,OptionsWidget(openglD._backgroundCol))
-        coordinatesWidget = CoordinatesWidget()
+        coordinatesWidget = CoordinatesWidget(app._opengl._renderers.gizmo)
         push!(widgets,coordinatesWidget)
         
         self = new(textFont,iconFont,pool,dependents,widgets,dock,coordinatesWidget)


### PR DESCRIPTION
* Fixed jumping gizmo at grazing angles (#106)
* Added get_ray(...) function for camera
* Holding X, Y, Z will move the gizmo (#7 from here to bottom)
* Holding two keys will move it on the plane
* Coordinates show up in a widget bottom left when point is selected
* Gizmo thickness and length changeable in options, UBO for them in renderer
* Gizmo moves relative to initial mouse position