### PR TITLE
Ortho matrix

### DIFF
--- a/assets/shaders/src/common_data.glsl
+++ b/assets/shaders/src/common_data.glsl
@@ -29,6 +29,16 @@ float zfar() { return _near_far_fov_hovered.y; }
 float fov() { return _near_far_fov_hovered.z; }
 uint hovered_id() { return floatBitsToUint(_near_far_fov_hovered.w); }
 
+float computeLinearDepth(float clip_space_depth) {
+    const float NEAR = znear();
+    const float FAR  = zfar();
+    if (fov() < 0.0) {
+        return mix(NEAR, FAR, clip_space_depth);
+    } else {
+        return ((FAR * NEAR) / (NEAR - FAR)) / (clip_space_depth - (FAR / (FAR - NEAR)));
+    }
+}
+
 #endif
 
 #ifdef RAY
@@ -36,10 +46,10 @@ uint hovered_id() { return floatBitsToUint(_near_far_fov_hovered.w); }
 vec3 rayDirection() {
     vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
     if (fov() < 0.0) {
-        return normalize(-backward);
+        return -backward;
     } else {
-        vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
-        vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
+        vec3 right  = vec3(V[0][0], V[1][0], V[2][0]);
+        vec3 up     = vec3(V[0][1], V[1][1], V[2][1]);
 
         float focal_length = -1.0 / tan(fov() * 0.5);
         vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 

--- a/assets/shaders/src/common_data.glsl
+++ b/assets/shaders/src/common_data.glsl
@@ -27,12 +27,14 @@ vec2 resolution() { return vec2(_light_side_width.w, _light_cam_heigth.w); }
 float znear() { return _near_far_fov_hovered.x; }
 float zfar() { return _near_far_fov_hovered.y; }
 float fov() { return _near_far_fov_hovered.z; }
+float orthoHalfHeight() { return -_near_far_fov_hovered.z; }
+bool isOrtho() { return fov() < 0.0; }
 uint hovered_id() { return floatBitsToUint(_near_far_fov_hovered.w); }
 
 float computeLinearDepth(float clip_space_depth) {
     const float NEAR = znear();
     const float FAR  = zfar();
-    if (fov() < 0.0) {
+    if (isOrtho()) {
         return mix(NEAR, FAR, clip_space_depth);
     } else {
         return ((FAR * NEAR) / (NEAR - FAR)) / (clip_space_depth - (FAR / (FAR - NEAR)));
@@ -44,30 +46,30 @@ float computeLinearDepth(float clip_space_depth) {
 #ifdef RAY
 #ifndef RAY_DEF
 vec3 rayDirection() {
-    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
-    if (fov() < 0.0) {
-        return -backward;
+    vec3 forward = -vec3(V[0][2], V[1][2], V[2][2]);
+    if (isOrtho()) {
+        return forward;
     } else {
         vec3 right  = vec3(V[0][0], V[1][0], V[2][0]);
         vec3 up     = vec3(V[0][1], V[1][1], V[2][1]);
 
-        float focal_length = -1.0 / tan(fov() * 0.5);
+        float focal_length = 1.0 / tan(fov() * 0.5);
         vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
         screen_uv.x *= aspect();
 
         return normalize(screen_uv.x  * right + 
                          screen_uv.y  * up + 
-                         focal_length * backward);
+                         focal_length * forward);
     }
 }
 
-vec3 ray_origin() {
-    if (fov() < 0.0) {
+vec3 rayOrigin() {
+    if (isOrtho()) {
         vec3 right = vec3(V[0][0], V[1][0], V[2][0]);
         vec3 up    = vec3(V[0][1], V[1][1], V[2][1]);
         vec2 uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0;
         uv.x *= aspect();
-        float ortho_scale = -fov();
+        float ortho_scale = orthoHalfHeight();
         return eye() + (uv.x * ortho_scale * right) + (uv.y * ortho_scale * up);
     } else {
         return eye();

--- a/assets/shaders/src/common_data.glsl
+++ b/assets/shaders/src/common_data.glsl
@@ -30,3 +30,39 @@ float fov() { return _near_far_fov_hovered.z; }
 uint hovered_id() { return floatBitsToUint(_near_far_fov_hovered.w); }
 
 #endif
+
+#ifdef RAY
+#ifndef RAY_DEF
+vec3 rayDirection() {
+    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
+    if (fov() < 0.0) {
+        return normalize(-backward);
+    } else {
+        vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
+        vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
+
+        float focal_length = -1.0 / tan(fov() * 0.5);
+        vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
+        screen_uv.x *= aspect();
+
+        return normalize(screen_uv.x  * right + 
+                         screen_uv.y  * up + 
+                         focal_length * backward);
+    }
+}
+
+vec3 ray_origin() {
+    if (fov() < 0.0) {
+        vec3 right = vec3(V[0][0], V[1][0], V[2][0]);
+        vec3 up    = vec3(V[0][1], V[1][1], V[2][1]);
+        vec2 uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0;
+        uv.x *= aspect();
+        float ortho_scale = -fov();
+        return eye() + (uv.x * ortho_scale * right) + (uv.y * ortho_scale * up);
+    } else {
+        return eye();
+    }
+}
+#define RAY_DEF
+#endif
+#endif

--- a/assets/shaders/src/postprocess/grid.frag
+++ b/assets/shaders/src/postprocess/grid.frag
@@ -1,5 +1,6 @@
 #version 460 core
 #extension GL_GOOGLE_include_directive : require
+#define RAY
 #include "../common_data.glsl"
 
 layout(location = 0) out vec4 color_out;
@@ -35,26 +36,12 @@ float computeLinearDepth(float clip_space_depth) {
     return ((FAR * NEAR) / (NEAR - FAR)) / (clip_space_depth - (FAR / (FAR - NEAR)));
 }
 
-vec3 rayDirection() {
-    vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
-    vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
-    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
-
-    float focal_length = -1.0 / tan(fov() * 0.5);
-    vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
-    screen_uv.x *= aspect();
-
-    return normalize(screen_uv.x  * right + 
-                     screen_uv.y  * up + 
-                     focal_length * backward);
-}
-
 void main() {
     const ivec2 coords = ivec2(gl_FragCoord.xy);
 
     vec3 ray_dir = rayDirection();
-    float t = -eye().z / ray_dir.z;
-    vec3 frag_position = eye() + t * ray_dir;
+    float t = -ray_origin().z / ray_dir.z;
+    vec3 frag_position = ray_origin() + t * ray_dir;
     
     float depth = texelFetch(depthTex, coords, 0).x;
     float depth_lin = computeLinearDepth(depth);

--- a/assets/shaders/src/postprocess/grid.frag
+++ b/assets/shaders/src/postprocess/grid.frag
@@ -30,12 +30,6 @@ vec4 grid(vec3 position, float scale) {
     return color;
 }
 
-float computeLinearDepth(float clip_space_depth) {
-    const float NEAR = znear();
-    const float FAR  = zfar();
-    return ((FAR * NEAR) / (NEAR - FAR)) / (clip_space_depth - (FAR / (FAR - NEAR)));
-}
-
 void main() {
     const ivec2 coords = ivec2(gl_FragCoord.xy);
 
@@ -45,13 +39,10 @@ void main() {
     
     float depth = texelFetch(depthTex, coords, 0).x;
     float depth_lin = computeLinearDepth(depth);
-    vec3 view_forward = normalize(at() - eye());
+    vec3 view_forward = -vec3(V[0][2], V[1][2], V[2][2]);
     float grid_view_z = t * dot(ray_dir, view_forward);
 
-    bool hit_in_front_of_camera = t > 0.0;
-    bool hit_in_render_distance = grid_view_z <= zfar() && grid_view_z < depth_lin;
-    bool outside_render_distance = depth == 1.0;
-    if (!hit_in_front_of_camera || !hit_in_render_distance || !outside_render_distance){
+    if (t < 0.0 || grid_view_z > zfar() || grid_view_z > depth_lin) {
         discard;
     }
 

--- a/assets/shaders/src/postprocess/grid.frag
+++ b/assets/shaders/src/postprocess/grid.frag
@@ -34,8 +34,8 @@ void main() {
     const ivec2 coords = ivec2(gl_FragCoord.xy);
 
     vec3 ray_dir = rayDirection();
-    float t = -ray_origin().z / ray_dir.z;
-    vec3 frag_position = ray_origin() + t * ray_dir;
+    float t = -rayOrigin().z / ray_dir.z;
+    vec3 frag_position = rayOrigin() + t * ray_dir;
     
     float depth = texelFetch(depthTex, coords, 0).x;
     float depth_lin = computeLinearDepth(depth);

--- a/assets/shaders/src/postprocess/grid.vert
+++ b/assets/shaders/src/postprocess/grid.vert
@@ -15,5 +15,5 @@ void main() {
     dist = distance(at(), eye());
     dist_10 = pow(10.0, floor(log(dist) / log(10.0)));
 
-	gl_Position = vec4(positions[gl_VertexID].xy, -1.0, 1.0);
+	gl_Position = vec4(positions[gl_VertexID].xy, 0.0, 1.0);
 }

--- a/assets/shaders/src/renderers/line/line_helpers.glsl
+++ b/assets/shaders/src/renderers/line/line_helpers.glsl
@@ -1,6 +1,7 @@
 #ifndef LINE_HELPERS
 #define LINE_HELPERS
 #extension GL_GOOGLE_include_directive : require
+#define RAY
 #include "../../common_data.glsl"
 #include "../color_output.glsl"
 
@@ -11,20 +12,6 @@ vec4 get_color(in vec4 color, in vec3 normal) {
     float diffuse = (max(dot(normal,light_cam()),0.0) * FRONT + max(dot(normal,light_side()),0.0) * SIDE) * DIFFUSE;
     float ambient = AMBIENT;
     return vec4(color.rgb * (diffuse + ambient), color.a);
-}
-
-vec3 rayDirection() {
-    vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
-    vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
-    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
-
-    float focal_length = -1.0 / tan(fov() * 0.5);
-    vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
-    screen_uv.x *= aspect();
-
-    return normalize(screen_uv.x  * right + 
-                     screen_uv.y  * up + 
-                     focal_length * backward);
 }
 
 float iSphere(vec3 ro, vec3 rd, vec3 sp, float r) {
@@ -108,7 +95,7 @@ float iUnevenCapsule(vec3 ro, vec3 rd, vec3 pa, vec3 pb, float ra, float rb, out
 }
 
 vec4 get_normal_depth(vec4 pos_rad_begin, vec4 pos_rad_end) {
-    vec3 ro = eye();
+    vec3 ro = ray_origin();
     vec3 rd = rayDirection();
     
     vec3 pa = pos_rad_begin.xyz;

--- a/assets/shaders/src/renderers/line/line_helpers.glsl
+++ b/assets/shaders/src/renderers/line/line_helpers.glsl
@@ -95,7 +95,7 @@ float iUnevenCapsule(vec3 ro, vec3 rd, vec3 pa, vec3 pb, float ra, float rb, out
 }
 
 vec4 get_normal_depth(vec4 pos_rad_begin, vec4 pos_rad_end) {
-    vec3 ro = ray_origin();
+    vec3 ro = rayOrigin();
     vec3 rd = rayDirection();
     
     vec3 pa = pos_rad_begin.xyz;

--- a/assets/shaders/src/renderers/sphere/sphere.frag
+++ b/assets/shaders/src/renderers/sphere/sphere.frag
@@ -1,5 +1,6 @@
 #version 460 core
 #extension GL_GOOGLE_include_directive : require
+#define RAY
 #include "../color_output.glsl"
 
 flat layout(location = 0) in vec4 color_in;
@@ -30,20 +31,6 @@ struct Sphere {
     vec3 c;    // center
     float r;   // radius
 };
-
-vec3 rayDirection() {
-    vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
-    vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
-    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
-
-    float focal_length = -1.0 / tan(fov() * 0.5);
-    vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
-    screen_uv.x *= aspect();
-
-    return normalize(screen_uv.x  * right + 
-                     screen_uv.y  * up + 
-                     focal_length * backward);
-}
 
 TraceResult intersectSphere(Ray ray, Sphere s){
     vec3 p0c = ray.p0 - s.c;
@@ -79,7 +66,7 @@ TraceResult intersectSphere(Ray ray, Sphere s){
 
 void main(){
     vec3 v = rayDirection();
-    Ray r = Ray(eye(), 0.01, v, 1000.0);
+    Ray r = Ray(ray_origin(), 0.01, v, 1000.0);
     
     Sphere s = Sphere(center_in,radius_in);
     TraceResult rs = intersectSphere(r,s);

--- a/assets/shaders/src/renderers/sphere/sphere.frag
+++ b/assets/shaders/src/renderers/sphere/sphere.frag
@@ -66,7 +66,7 @@ TraceResult intersectSphere(Ray ray, Sphere s){
 
 void main(){
     vec3 v = rayDirection();
-    Ray r = Ray(ray_origin(), 0.01, v, 1000.0);
+    Ray r = Ray(rayOrigin(), 0.01, v, 1000.0);
     
     Sphere s = Sphere(center_in,radius_in);
     TraceResult rs = intersectSphere(r,s);

--- a/assets/shaders/src/renderers/sphere/sphere.vert
+++ b/assets/shaders/src/renderers/sphere/sphere.vert
@@ -42,21 +42,27 @@ void main() {
     if (dist < radius) {
         gl_Position = vec4(base_offset,0.0,1.0) * near;
     } else {
-        vec3 a = (eye() - center) / dist; 
-        vec3 b = vec3(0.0, 0.0, 1.0);
+        if (P[3][3] == 1.0) {
+            vec4 viewPos = V * vec4(center, 1.0);
+            viewPos.xy += base_offset * radius;
+            gl_Position = P * viewPos;
+        } else {
+            vec3 a = (eye() - center) / dist; 
+            vec3 b = vec3(0.0, 0.0, 1.0);
 
-        vec3 v = cross(a, b);
-        float c = dot(a, b);
-        float k = 1.0 / (1.0 + c);
+            vec3 v = cross(a, b);
+            float c = dot(a, b);
+            float k = 1.0 / (1.0 + c);
 
-        mat3 Rot = c > -0.9999 ? mat3(
-            v.x * v.x * k + c,   v.y * v.x * k - v.z, v.z * v.x * k + v.y,
-            v.x * v.y * k + v.z, v.y * v.y * k + c,   v.z * v.y * k - v.x,
-            v.x * v.z * k - v.y, v.y * v.z * k + v.x, v.z * v.z * k + c
-        ) : mat3(-1.0);
+            mat3 Rot = c > -0.9999 ? mat3(
+                v.x * v.x * k + c,   v.y * v.x * k - v.z, v.z * v.x * k + v.y,
+                v.x * v.y * k + v.z, v.y * v.y * k + c,   v.z * v.y * k - v.x,
+                v.x * v.z * k - v.y, v.y * v.z * k + v.x, v.z * v.z * k + c
+            ) : mat3(-1.0);
 
-        vec3 surfaceCenter = center + a * radius;
-        vec3 offset = Rot * vec3(base_offset,0.0) * radius;
-        gl_Position = VP * vec4(surfaceCenter + offset, 1.0);
+            vec3 surfaceCenter = center + a * radius;
+            vec3 offset = Rot * vec3(base_offset,0.0) * radius;
+            gl_Position = VP * vec4(surfaceCenter + offset, 1.0);
+        }
     }
 }

--- a/assets/shaders/src/renderers/sphere/sphere.vert
+++ b/assets/shaders/src/renderers/sphere/sphere.vert
@@ -39,30 +39,21 @@ void main() {
     radius_out = radius;
 
     float dist = distance(eye(), center);
-    if (dist < radius) {
-        gl_Position = vec4(base_offset,0.0,1.0) * near;
+    if (isOrtho()) {
+        vec4 viewPos = V * vec4(center, 1.0);
+        viewPos.xy += base_offset * radius;
+        viewPos.z -= radius;
+        gl_Position = P * viewPos;
+    } else if (dist < radius) {
+        gl_Position = vec4(base_offset, 0.0, 1.0) * near;
     } else {
-        if (P[3][3] == 1.0) {
-            vec4 viewPos = V * vec4(center, 1.0);
-            viewPos.xy += base_offset * radius;
-            gl_Position = P * viewPos;
-        } else {
-            vec3 a = (eye() - center) / dist; 
-            vec3 b = vec3(0.0, 0.0, 1.0);
+        vec3 camUp = vec3(V[0][1], V[1][1], V[2][1]);
+        vec3 forward = normalize(eye() - center);
+        vec3 right = normalize(cross(camUp, forward));
+        vec3 up = cross(forward, right);
 
-            vec3 v = cross(a, b);
-            float c = dot(a, b);
-            float k = 1.0 / (1.0 + c);
-
-            mat3 Rot = c > -0.9999 ? mat3(
-                v.x * v.x * k + c,   v.y * v.x * k - v.z, v.z * v.x * k + v.y,
-                v.x * v.y * k + v.z, v.y * v.y * k + c,   v.z * v.y * k - v.x,
-                v.x * v.z * k - v.y, v.y * v.z * k + v.x, v.z * v.z * k + c
-            ) : mat3(-1.0);
-
-            vec3 surfaceCenter = center + a * radius;
-            vec3 offset = Rot * vec3(base_offset,0.0) * radius;
-            gl_Position = VP * vec4(surfaceCenter + offset, 1.0);
-        }
+        vec3 surfaceCenter = center + forward * radius;
+        vec3 offset = (right * base_offset.x + up * base_offset.y) * radius;
+        gl_Position = VP * vec4(surfaceCenter + offset, 1.0);
     }
 }

--- a/assets/shaders/src/renderers/sphere/sphere_transparent.frag
+++ b/assets/shaders/src/renderers/sphere/sphere_transparent.frag
@@ -57,7 +57,7 @@ TraceResult intersectSphere(Ray ray, Sphere s){
 
 void main(){
     vec3 v = rayDirection();
-    Ray r = Ray(ray_origin(), 0.01, v, 1000.0);
+    Ray r = Ray(rayOrigin(), 0.01, v, 1000.0);
     
     Sphere s = Sphere(center_in,radius_in);
     TraceResult rs = intersectSphere(r,s);

--- a/assets/shaders/src/renderers/sphere/sphere_transparent.frag
+++ b/assets/shaders/src/renderers/sphere/sphere_transparent.frag
@@ -1,6 +1,7 @@
 #version 460 core
 #extension GL_GOOGLE_include_directive : require
 #define TRANSPARENT
+#define RAY
 #include "../color_output.glsl"
 
 flat layout(location = 0) in vec4 color_in;
@@ -32,20 +33,6 @@ struct Sphere {
     float r;   // radius
 };
 
-vec3 rayDirection() {
-    vec3 right    = vec3(V[0][0], V[1][0], V[2][0]);
-    vec3 up       = vec3(V[0][1], V[1][1], V[2][1]);
-    vec3 backward = vec3(V[0][2], V[1][2], V[2][2]);
-
-    float focal_length = -1.0 / tan(fov() * 0.5);
-    vec2 screen_uv = (gl_FragCoord.xy / resolution()) * 2.0 - 1.0; 
-    screen_uv.x *= aspect();
-
-    return normalize(screen_uv.x  * right + 
-                     screen_uv.y  * up + 
-                     focal_length * backward);
-}
-
 TraceResult intersectSphere(Ray ray, Sphere s){
     vec3 p0c = ray.p0 - s.c;
     float a = dot(ray.v, ray.v);
@@ -70,7 +57,7 @@ TraceResult intersectSphere(Ray ray, Sphere s){
 
 void main(){
     vec3 v = rayDirection();
-    Ray r = Ray(eye(), 0.01, v, 1000.0);
+    Ray r = Ray(ray_origin(), 0.01, v, 1000.0);
     
     Sphere s = Sphere(center_in,radius_in);
     TraceResult rs = intersectSphere(r,s);

--- a/src/Renderers/gizmo_renderer.jl
+++ b/src/Renderers/gizmo_renderer.jl
@@ -127,7 +127,7 @@ function _planeLineIntersection(eye::Vec3D, ray::Vec3D, plane_position::Vec3D, p
         return nothing
     end
 end
-function _moveAlongAxis(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Vec3D,Nothing}
+function _moveAlongAxis(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F, origin::Vec3F)::Union{Vec3D,Nothing}
     axis_vector = AXIS_TO_VECTOR[gizmo.axes]
     if (gizmo.first_move)
         # ? Perpendicular to ray and the axis
@@ -138,7 +138,7 @@ function _moveAlongAxis(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Ve
     
     angleDiff = dot(normalize(app._cam.at - app._cam.eye), normalize(gizmo.initial_plane_normal))
     if (abs(angleDiff) >= MIN_VIEW_ANGLE_DIFF)
-        intersection = _planeLineIntersection(Vec3D(app._cam.eye), Vec3D(ray), gizmo.position, Vec3D(gizmo.initial_plane_normal))
+        intersection = _planeLineIntersection(Vec3D(origin), Vec3D(ray), gizmo.position, Vec3D(gizmo.initial_plane_normal))
         if (intersection !== nothing)
             # ? Projecting onto axis to get length
             t = dot(intersection - gizmo.position, axis_vector)
@@ -148,13 +148,13 @@ function _moveAlongAxis(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Ve
 
     return nothing
 end
-function _moveAlongPlane(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F)::Union{Vec3D,Nothing}
+function _moveAlongPlane(app::AppDNA, gizmo::GizmoRenderer, ray::Vec3F, origin::Vec3F)::Union{Vec3D,Nothing}
     for axis in ALL_AXES
         # ? Finds the perpendicular axis to the plane that'll be used as its normal
         if (gizmo.axes & axis == 0)
             angleDiff = dot(normalize(app._cam.at - app._cam.eye), normalize(AXIS_TO_VECTOR[axis]))
             if (abs(angleDiff) >= MIN_VIEW_ANGLE_DIFF)
-                intersection = _planeLineIntersection(Vec3D(app._cam.eye), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
+                intersection = _planeLineIntersection(Vec3D(origin), Vec3D(ray), gizmo.position, Vec3D(AXIS_TO_VECTOR[axis]))
                 if (intersection !== nothing)
                     return intersection
                 end
@@ -168,10 +168,11 @@ end
 
 function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     ray = get_ray(app, mouseX, mouseY)
+    origin = get_origin(app, mouseX, mouseY)
     newPoint = nothing
     
     if (gizmo.first_move)
-        toPoint = normalize(gizmo.position - app._cam.eye)
+        toPoint = normalize(gizmo.position - origin)
         # ? Stores the initial difference between where the eye-point vector and the eye-mouse ray
         gizmo.initial_ray_diff = toPoint - ray
     end
@@ -180,9 +181,9 @@ function _move_gizmo!(app::AppDNA, gizmo::GizmoRenderer, mouseX, mouseY)
     ray = Vec3F(ray + gizmo.initial_ray_diff)
 
     if (any(a -> a == gizmo.axes, ALL_AXES))
-        newPoint = _moveAlongAxis(app, gizmo, ray)
+        newPoint = _moveAlongAxis(app, gizmo, ray, origin)
     else
-        newPoint = _moveAlongPlane(app, gizmo, ray)
+        newPoint = _moveAlongPlane(app, gizmo, ray, origin)
     end
 
     if (gizmo.first_move && newPoint !== nothing)

--- a/src/app.jl
+++ b/src/app.jl
@@ -74,7 +74,8 @@ sceneChanged(self::App)::Nothing = (self._scene_change = true;nothing)
 function resize!(self::App, event::Event)::Bool
     resize!(self._glfw, event.width, event.height)
     resize!(self._opengl, self._glfw)
-    set_aspect!(self._cam, self._glfw.width, self._glfw.height)
+    self._cam.aspect = self._glfw.width / self._glfw.height
+    calculate_projection_matrix!(self._cam)
     return false
 end
 
@@ -105,12 +106,9 @@ end
 
 function updateCam!(self::App,delta_time::Float64)::Bool
     update!(self._manipulator, delta_time, self._inputs)
-    self._opengl._camPos = self._cam._eye
-    vp,v,p = get_matrices(self._cam)
-    change = vp != self._opengl._vp
-    self._opengl._vp = vp
-    self._opengl._v  = v
-    self._opengl._p  = p
+    vp = get_matrices(self._cam)[1]
+    change = vp != self._opengl._last_vp
+    self._opengl._last_vp = vp
     return change
 end
 
@@ -211,7 +209,8 @@ function init!(self::App)
     end
     
     init!(self._glfw, true)
-    set_aspect!(self._cam,self._glfw.width,self._glfw.height)
+    self._cam.aspect = self._glfw.width / self._glfw.height
+    calculate_projection_matrix!(self._cam)
     self._opengl = OpenGLData(self._glfw,self._asset_watcher)
     setup_callbacks(self)
     setup_event_handles(self._glfw,self._inputs)

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -1,65 +1,78 @@
 using LinearAlgebra
 
 @kwdef mutable struct Camera
-    _eye::Vec3F= Vec3F(0.0f0,-5.0f0,1.0f0)
-    _up::Vec3F = Vec3F(0.0f0,0.0f0,1.0f0)
-    _at::Vec3F = Vec3F(0.0f0,0.0f0,0.0f0)
+    eye::Vec3F= Vec3F(0.0f0,-5.0f0,1.0f0)
+    at::Vec3F = Vec3F(0.0f0,0.0f0,0.0f0)
+    up::Vec3F = Vec3F(0.0f0,0.0f0,1.0f0)
 
-    _view::Mat4T{Float32} = mat4(1.0f0)
-    _proj::Mat4T{Float32} = mat4(1.0f0)
-    _view_proj::Mat4T{Float32} = mat4(1.0f0)
+    view::Mat4T{Float32} = mat4(0.0f0)
+    proj::Mat4T{Float32} = mat4(0.0f0)
+    view_proj::Mat4T{Float32} = mat4(0.0f0)
 
-    _fov::Float32 = 50.0f0
-    _zNear::Float32 = 0.01f0
-    _zFar::Float32 = 999.0f0
-    _aspect::Float32 = 1280.0f0 / 720.0f0
+    fov::Float32 = 50.0f0
+    zNear::Float32 = 0.01f0
+    zFar::Float32 = 999.0f0
+    aspect::Float32 = 1280.0f0 / 720.0f0
 end
 
 function defaultCamera()::Camera
     camera = Camera()
-    camera._proj = perspective(deg2rad(camera._fov),camera._aspect,camera._zNear,camera._zFar)
-    camera._view = lookat(camera._eye,camera._at,camera._up)
+    calculate_matrices!(camera)
     return camera
 end
 
-function ortho(fovy::T, aspect::T, zNear::T, zFar::T, dist::T) :: Mat4T{T} where T
-    a  = tan(fovy / T(2))
-    dz = zFar - zNear
-    return Mat4T{T}(
-        one(T) / (dist * aspect * a), 0,                            0,                    0,
-        0,                            one(T) / (dist * a),          0,                    0,
-        0,                            0,                            -T(2) / dz,           0,
-        0,                            0,                            -(zFar + zNear) / dz, one(T)
+is_perspective(camera::Camera)::Bool = camera.proj[16] != 1.0f0
+function set_ortho!(camera::Camera)::Nothing
+    dist::Float32 = norm(camera.at - camera.eye)
+    fovy::Float32 = deg2rad(camera.fov)
+    a::Float32  = tan(fovy / 2.0f0)
+    dz::Float32 = camera.zFar - camera.zNear
+    ortho = Mat4T{Float32}(
+        1.0f0 / (dist * camera.aspect * a), 0.0f0,                       0.0f0,                        0.0f0,
+        0.0f0,                       1.0f0 / (dist * a),          0.0f0,                        0.0f0,
+        0.0f0,                       0.0f0,                       -2.0f0 / dz,                  0.0f0,
+        0.0f0,                       0.0f0,                       -(camera.zFar + camera.zNear) / dz, 1.0f0
     )
+    camera.proj = ortho
+    return nothing
+end
+function set_perspective!(camera::Camera)::Nothing
+    camera.proj = perspective(deg2rad(camera.fov),camera.aspect,camera.zNear,camera.zFar)
+    return nothing
 end
 
-function ortho(cam::Camera)
-    dist = norm(cam._at - cam._eye)
-    fovy_rad = deg2rad(cam._fov) # Converts degrees to radians
-    return ortho(fovy_rad, cam._aspect, cam._zNear, cam._zFar, dist)
-end
+swap_projection!(cam::Camera) = is_perspective(cam) ? set_ortho!(cam) : set_perspective!(cam)
 
-function swap_projection(cam::Camera)
-    if cam._proj[16] == 1.0f0
-        cam._proj = perspective(deg2rad(cam._fov),cam._aspect,cam._zNear,cam._zFar)
-    else
-        cam._proj = ortho(cam)
-    end
+function calculate_projection_matrix!(camera::Camera)::Nothing
+    is_perspective(camera) ? set_perspective!(camera) : set_ortho!(camera)
+    camera.view_proj = camera.proj * camera.view
+    return nothing
+end
+function calculate_view_matrix!(camera::Camera)::Nothing
+    camera.view = lookat(camera.eye,camera.at,camera.up)
+    camera.view_proj = camera.proj * camera.view
+    return nothing
+end
+function calculate_matrices!(camera::Camera)::Nothing
+    camera.view = lookat(camera.eye,camera.at,camera.up)
+    is_perspective(camera) ? set_perspective!(camera) : set_ortho!(camera)
+    camera.view_proj = camera.proj * camera.view
+    return nothing
 end
 
 function get_fov(self::Camera)::Float32
-    if self._proj[16] == 1.0f0
-        d = norm(self._at - self._eye)
-        a  = tan(deg2rad(self._fov) / 2.0f0)
-        return -d * a;
+    if is_perspective(self)
+        return deg2rad(self.fov)
     else
-        return deg2rad(self._fov)
+        d = norm(self.at - self.eye)
+        a  = tan(deg2rad(self.fov) / 2.0f0)
+        return -d * a;
     end
 end
 
 function get_lights(self::Camera, z::Float32 = 45.0f0)
     z = deg2rad(z)
-    l_cam = normalize(self._at - self._eye)
+    l_cam = normalize(self.at - self.eye)
     rot = Mat3T{Float32}(
         cos(z), -sin(z), 0.0f0,
         sin(z),  cos(z), 0.0f0,
@@ -70,40 +83,5 @@ function get_lights(self::Camera, z::Float32 = 45.0f0)
 end
 
 function get_matrices(self::Camera)
-    return self._view_proj, self._view, self._proj
-end
-
-function set_view!(self::Camera,eye::Vec3F,at::Vec3F,up::Vec3F)
-    self._eye = eye
-    self._at = at
-    self._view = lookat(self._eye,self._at,up)
-    return nothing
-end
-function set_proj!(self::Camera,fov,width,height,zn,zf)
-    self._fov = Float32(fov)
-    self._aspect = Float32(width)/Float32(height)
-    self._zNear = Float32(zn)
-    self._zFar = Float32(zf)
-    self._proj = perspective(deg2rad(self._fov),self._aspect,self._zNear,self._zFar)
-    return nothing
-end
-function set_fov!(self::Camera,fov)
-	self._fov = Float32(fov)
-	self._proj = perspective(deg2rad(self._fov),self._aspect,self._zNear,self._zFar)
-    return nothing
-end
-function set_aspect!(self::Camera,width,height)
-    self._aspect = Float32(width/height)
-	self._proj = perspective(deg2rad(self._fov),self._aspect,self._zNear,self._zFar)
-    return nothing
-end
-function set_znear!(self::Camera,zn)
-	self._zNear = Float32(zn)
-	self._proj = perspective(deg2rad(self._fov),self._aspect,self._zNear,self._zFar)
-    return nothing
-end
-function set_zfar!(self::Camera,zf)
-	self._zFar = Float32(zf)
-	self._proj = perspective(deg2rad(self._fov),self._aspect,self._zNear,self._zFar)
-    return nothing
+    return self.view_proj, self.view, self.proj
 end

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -22,6 +22,41 @@ function defaultCamera()::Camera
     return camera
 end
 
+function ortho(fovy::T, aspect::T, zNear::T, zFar::T, dist::T) :: Mat4T{T} where T
+    a  = tan(fovy / T(2))
+    dz = zFar - zNear
+    return Mat4T{T}(
+        one(T) / (dist * aspect * a), 0,                            0,                    0,
+        0,                            one(T) / (dist * a),          0,                    0,
+        0,                            0,                            -T(2) / dz,           0,
+        0,                            0,                            -(zFar + zNear) / dz, one(T)
+    )
+end
+
+function ortho(cam::Camera)
+    dist = norm(cam._at - cam._eye)
+    fovy_rad = deg2rad(cam._fov) # Converts degrees to radians
+    return ortho(fovy_rad, cam._aspect, cam._zNear, cam._zFar, dist)
+end
+
+function swap_projection(cam::Camera)
+    if cam._proj[16] == 1.0f0
+        cam._proj = perspective(deg2rad(cam._fov),cam._aspect,cam._zNear,cam._zFar)
+    else
+        cam._proj = ortho(cam)
+    end
+end
+
+function get_fov(self::Camera)::Float32
+    if self._proj[16] == 1.0f0
+        d = norm(self._at - self._eye)
+        a  = tan(deg2rad(self._fov) / 2.0f0)
+        return -d * a;
+    else
+        return deg2rad(self._fov)
+    end
+end
+
 function get_lights(self::Camera, z::Float32 = 45.0f0)
     z = deg2rad(z)
     l_cam = normalize(self._at - self._eye)

--- a/src/camera.jl
+++ b/src/camera.jl
@@ -87,9 +87,14 @@ function get_matrices(self::Camera)
 end
 function get_ray(app::AppDNA, x, y)::Vec3F
     self = app._cam
+    forward = -Vec3F(self.view[3,1], self.view[3,2], self.view[3,3])
+    
+    if !is_perspective(self) 
+        return forward 
+    end
+
     mouse = Vec2F(((x + 0.5) / app._glfw.width) * 2.0 - 1.0, ((y + 0.5) / app._glfw.height) * 2.0 - 1.0)
 
-    forward = -Vec3F(self.view[3,1],self.view[3,2],self.view[3,3])
     right = Vec3F(self.view[1,1],self.view[1,2],self.view[1,3])
     camUp = Vec3F(self.view[2,1],self.view[2,2],self.view[2,3])
 
@@ -101,4 +106,22 @@ function get_ray(app::AppDNA, x, y)::Vec3F
     ray = normalize(nearPlaneMouse - self.eye)
 
     return ray
+end
+
+function get_origin(app::AppDNA, x, y)::Vec3F
+    self = app._cam
+    if is_perspective(self) return self.eye end
+
+    right = Vec3F(self.view[1,1], self.view[1,2], self.view[1,3])
+    camUp = Vec3F(self.view[2,1], self.view[2,2], self.view[2,3])
+
+    mouse = Vec2F(((x + 0.5) / app._glfw.width) * 2.0 - 1.0, ((y + 0.5) / app._glfw.height) * 2.0 - 1.0)
+
+    d = norm(self.at - self.eye)
+    a = tan(deg2rad(self.fov) / 2.0f0)
+
+    halfHeight = d * a
+    halfWidth = halfHeight * self.aspect
+
+    return self.eye + right * (mouse[1] * halfWidth) + camUp * (mouse[2] * halfHeight)
 end

--- a/src/camera_manipulator.jl
+++ b/src/camera_manipulator.jl
@@ -148,6 +148,11 @@ function register_callbacks!(inputs::Inputs, cam::OrbitalCamera)::Nothing
         return true
     end
 
+    register_callback!(inputs, KEY_DOWN, Cint(GLFW.KEY_KP_5)) do ev
+        swap_projection(cam._cam)
+        return true
+    end
+
 
     # --- KEYBOARD UP EVENTS ---
     register_callback!(ev -> (cam._forward = 0; true), inputs, KEY_UP, Cint(GLFW.KEY_W))

--- a/src/camera_manipulator.jl
+++ b/src/camera_manipulator.jl
@@ -26,7 +26,7 @@ mutable struct OrbitalCamera <: CameraManipulator
 end
 
 function create_orbital_manipulator(camera::Camera)::OrbitalCamera
-    to_aim = camera._at - camera._eye
+    to_aim = camera.at - camera.eye
     distance = Float32(norm(to_aim))
 
     u = atan(to_aim.y, to_aim.x)
@@ -52,7 +52,7 @@ function update!(self::OrbitalCamera,deltaTime,inputs::Inputs)
 
     right = Vec3F(cos(self._u+0.5π),sin(self._u+0.5π),0.0)
     up = normalize(cross(right, -lookDirection));
-    forward = normalize(cross(right, self._cam._up));
+    forward = normalize(cross(right, self._cam.up));
 
     distance = exp(self._zoom)-1.0f0
     # WASD movement
@@ -62,17 +62,19 @@ function update!(self::OrbitalCamera,deltaTime,inputs::Inputs)
 
     # Mouse movement
     eye, at = if self._move_state != _ORBITAL_LOOK
-        eye = self._cam._at - distance * lookDirection
-        at = self._cam._at
+        eye = self._cam.at - distance * lookDirection
+        at = self._cam.at
         eye, at
     else
-        at = self._cam._eye + distance * lookDirection
-        eye = self._cam._eye
+        at = self._cam.eye + distance * lookDirection
+        eye = self._cam.eye
         eye, at
     end
     
-    set_view!(self._cam,eye + d_position,at + d_position,up)
-    self._cam._view_proj = self._cam._proj * self._cam._view
+    self._cam.eye = eye + d_position
+    self._cam.at = at + d_position
+    self._cam.up = up
+    calculate_view_matrix!(self._cam)
 end
 
 _forward(cam::OrbitalCamera)::Bool = (cam._forward = 1; true)
@@ -149,7 +151,7 @@ function register_callbacks!(inputs::Inputs, cam::OrbitalCamera)::Nothing
     end
 
     register_callback!(inputs, KEY_DOWN, Cint(GLFW.KEY_KP_5)) do ev
-        swap_projection(cam._cam)
+        swap_projection!(cam._cam)
         return true
     end
 
@@ -216,14 +218,14 @@ function register_callbacks!(inputs::Inputs, cam::OrbitalCamera)::Nothing
             cam._u += du
             cam._v = clamp(cam._v + dv, 0.0f0, Float32(π))
         elseif cam._move_state == _ORBITAL_PAN
-            lookat = normalize(cam._cam._at - cam._cam._eye)
+            lookat = normalize(cam._cam.at - cam._cam.eye)
             right = Vec3F(cos(cam._u + 0.5f0 * Float32(π)), sin(cam._u + 0.5f0 * Float32(π)), 0.0f0)
             up = normalize(cross(right, lookat))
             delta = up * dv + right * du
             delta *= (exp(cam._zoom) - 1.0f0) / 15.0f0
 
-            cam._cam._eye += delta
-            cam._cam._at += delta
+            cam._cam.eye += delta
+            cam._cam.at += delta
         end
         return cam._capture_mouse
     end
@@ -236,12 +238,12 @@ function register_callbacks!(inputs::Inputs, cam::OrbitalCamera)::Nothing
         new_distance = exp(cam._zoom) - 1.0f0
         delta_distance = new_distance - old_distance
 
-        lookat = normalize(cam._cam._at - cam._cam._eye)
+        lookat = normalize(cam._cam.at - cam._cam.eye)
         right = Vec3F(cos(cam._u + 0.5f0 * Float32(π)), sin(cam._u + 0.5f0 * Float32(π)), 0.0f0)
         up = normalize(cross(right, lookat))
 
-        tan_half_fov_Y = tan(deg2rad(cam._cam._fov / 2.0f0))
-        tan_half_fov_X = tan_half_fov_Y * cam._cam._aspect
+        tan_half_fov_Y = tan(deg2rad(cam._cam.fov / 2.0f0))
+        tan_half_fov_X = tan_half_fov_Y * cam._cam.aspect
         
         x = (Float32(ev.x) * 2.0f0 - 1.0f0)
         y = (Float32(ev.y) * 2.0f0 - 1.0f0)
@@ -249,8 +251,9 @@ function register_callbacks!(inputs::Inputs, cam::OrbitalCamera)::Nothing
         h = tan_half_fov_Y * old_distance * (delta_distance / old_distance) * y
 
         offset = right * w + up * h
-        cam._cam._at += offset
-        cam._cam._eye += offset
+        cam._cam.at += offset
+        cam._cam.eye += offset
+        if !is_perspective(cam._cam) calculate_projection_matrix!(cam._cam) end
         return true
     end
     

--- a/src/opengl_data.jl
+++ b/src/opengl_data.jl
@@ -437,7 +437,7 @@ function _ubo_update!(self::OpenGLData,cam::Camera,hovered::UInt32)
         vp,v,p,
         Vec4F(-side_light...,width),Vec4F(-cam_light...,height),
         Vec4F(cam._eye...,width/height),Vec4F(cam._at...,reinterpret(Float32,UInt32(self._window.width))),
-        Vec4F(cam._zNear,cam._zFar,deg2rad(cam._fov),reinterpret(Float32,hovered))
+        Vec4F(cam._zNear,cam._zFar,get_fov(cam),reinterpret(Float32,hovered))
     )
     glBindBufferBase(GL_UNIFORM_BUFFER, 10, id(self._ubo))
 end

--- a/src/opengl_data.jl
+++ b/src/opengl_data.jl
@@ -68,10 +68,7 @@ mutable struct OpenGLData
 
     _backgroundCol::Vec3F
 
-    _vp::Mat4T{Float32}
-    _v::Mat4T{Float32}
-    _p::Mat4T{Float32}
-    _camPos::Vec3F
+    _last_vp::Mat4T{Float32}
 
     # GREEN Thread, runs this inside Init, after this construction can begin
     function OpenGLData(window::GLFWData,asset_watcher::Union{Nothing,AssetWatcher})
@@ -184,10 +181,7 @@ mutable struct OpenGLData
         observers::Vector{RendererDNA} = RendererDNA[]
         renderers = PrimitiveRenderers(pipeline_loader,window.scale)
         
-        p = perspective(Float32(70.0),Float32(window.width/window.height),Float32(0.01),Float32(100.0))
-        v = lookat(Vec3F(0.0,-5.0,0.0),Vec3F(0.0,0.0,0.0),Vec3F(0.0,0.0,1.0))
-        vp = p * v 
-        camPos = Vec3F(0.0,0.0,0.0)
+        last_vp = mat4(1.0f0) 
 
         self = new(window,profiler,passes,cpu_stopwatch,pipeline_loader,observers,renderers,
             transparent_color_combiner,transparent_id_combiner,highlighter,buffer_clear,grid,
@@ -195,7 +189,7 @@ mutable struct OpenGLData
             opaqueFBO,behindOpaqueFBO,transparentFBO,
             ubo,pixel_buffer_dist,pixel_buffer_col,pixel_buffer_id,empty_vao,
             Vec3F(0.73,0.73,0.73),
-            vp,v,p,camPos)
+            last_vp)
         
         self._observers = create_dependent_observers(self)
         return self
@@ -436,8 +430,8 @@ function _ubo_update!(self::OpenGLData,cam::Camera,hovered::UInt32)
     self._ubo[1] = UBO_Data(
         vp,v,p,
         Vec4F(-side_light...,width),Vec4F(-cam_light...,height),
-        Vec4F(cam._eye...,width/height),Vec4F(cam._at...,reinterpret(Float32,UInt32(self._window.width))),
-        Vec4F(cam._zNear,cam._zFar,get_fov(cam),reinterpret(Float32,hovered))
+        Vec4F(cam.eye...,cam.aspect),Vec4F(cam.at...,reinterpret(Float32,UInt32(self._window.width))),
+        Vec4F(cam.zNear,cam.zFar,get_fov(cam),reinterpret(Float32,hovered))
     )
     glBindBufferBase(GL_UNIFORM_BUFFER, 10, id(self._ubo))
 end


### PR DESCRIPTION
You can switch between perspective and orthographic projection with keypad 5.
It closes #110
"Point(1,2) constructor that only allows x,y movement afterwards" and "Curve callback returning only x,y coordinates (zero auto-appended Z coord)" was already implemented, this implements "2D camera mode(s)"

The complex number support should be its own issue